### PR TITLE
feat: Add repeatable TODO functionality

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -154,7 +154,9 @@ Authorization: Bearer <JWT_TOKEN>
   "description": "詳細説明（任意）",
   "priority": "HIGH",
   "dueDate": "2024-12-31",
-  "parentId": null
+  "parentId": null,
+  "isRepeatable": false,
+  "repeatConfig": null
 }
 ```
 
@@ -168,6 +170,9 @@ Authorization: Bearer <JWT_TOKEN>
   "priority": "HIGH",
   "dueDate": "2024-12-31",
   "parentId": null,
+  "isRepeatable": false,
+  "repeatConfig": null,
+  "originalTodoId": null,
   "createdAt": "2024-01-01T09:00:00+09:00",
   "updatedAt": "2024-01-01T09:00:00+09:00"
 }
@@ -365,15 +370,211 @@ Authorization: Bearer <JWT_TOKEN>
     "priority": "MEDIUM",
     "dueDate": "2024-12-31",
     "parentId": 1,
+    "isRepeatable": false,
+    "repeatConfig": null,
+    "originalTodoId": null,
     "createdAt": "2024-01-01T09:30:00+09:00",
     "updatedAt": "2024-01-01T09:30:00+09:00"
   }
 ]
 ```
 
+## 🔒 繰り返しTODOエンドポイント（認証必須）
+
+### 11. 繰り返しTODO作成
+```
+POST /api/v1/todos
+Authorization: Bearer <JWT_TOKEN>
+```
+
+**リクエストボディ（毎日繰り返し）**:
+```json
+{
+  "title": "毎日の運動",
+  "description": "30分間のウォーキング",
+  "priority": "HIGH",
+  "dueDate": "2025-01-01",
+  "parentId": null,
+  "isRepeatable": true,
+  "repeatConfig": {
+    "repeatType": "DAILY",
+    "interval": 1,
+    "daysOfWeek": null,
+    "dayOfMonth": null,
+    "endDate": null
+  }
+}
+```
+
+**リクエストボディ（週次繰り返し）**:
+```json
+{
+  "title": "ジム通い",
+  "description": "筋力トレーニング",
+  "priority": "MEDIUM",
+  "dueDate": "2025-01-06",
+  "parentId": null,
+  "isRepeatable": true,
+  "repeatConfig": {
+    "repeatType": "WEEKLY",
+    "interval": 1,
+    "daysOfWeek": [1, 3, 5],
+    "dayOfMonth": null,
+    "endDate": null
+  }
+}
+```
+
+**リクエストボディ（月次繰り返し）**:
+```json
+{
+  "title": "月次レポート",
+  "description": "月末のレポート作成",
+  "priority": "HIGH",
+  "dueDate": "2025-01-31",
+  "parentId": null,
+  "isRepeatable": true,
+  "repeatConfig": {
+    "repeatType": "MONTHLY",
+    "interval": 1,
+    "daysOfWeek": null,
+    "dayOfMonth": 31,
+    "endDate": "2025-12-31"
+  }
+}
+```
+
+**レスポンス** (201 Created):
+```json
+{
+  "id": 1,
+  "title": "毎日の運動",
+  "description": "30分間のウォーキング",
+  "status": "TODO",
+  "priority": "HIGH",
+  "dueDate": "2025-01-01",
+  "parentId": null,
+  "isRepeatable": true,
+  "repeatConfig": {
+    "repeatType": "DAILY",
+    "interval": 1,
+    "daysOfWeek": null,
+    "dayOfMonth": null,
+    "endDate": null
+  },
+  "originalTodoId": null,
+  "createdAt": "2025-01-01T09:00:00+09:00",
+  "updatedAt": "2025-01-01T09:00:00+09:00"
+}
+```
+
+### 12. 繰り返し可能なTODO一覧取得
+```
+GET /api/v1/todos/repeatable
+Authorization: Bearer <JWT_TOKEN>
+```
+
+**レスポンス** (200 OK):
+認証済みユーザーの繰り返し設定が有効なTODOのみが返されます。
+```json
+[
+  {
+    "id": 1,
+    "title": "毎日の運動",
+    "description": "30分間のウォーキング",
+    "status": "TODO",
+    "priority": "HIGH",
+    "dueDate": "2025-01-01",
+    "parentId": null,
+    "isRepeatable": true,
+    "repeatConfig": {
+      "repeatType": "DAILY",
+      "interval": 1,
+      "daysOfWeek": null,
+      "dayOfMonth": null,
+      "endDate": null
+    },
+    "originalTodoId": null,
+    "createdAt": "2025-01-01T09:00:00+09:00",
+    "updatedAt": "2025-01-01T09:00:00+09:00"
+  }
+]
+```
+
+### 13. 繰り返しTODOのインスタンス一覧取得
+```
+GET /api/v1/todos/{originalTodoId}/instances
+Authorization: Bearer <JWT_TOKEN>
+```
+
+**パスパラメータ**:
+- `originalTodoId`: 元の繰り返しTODO ID (Long)
+
+**レスポンス** (200 OK):
+指定された繰り返しTODOから自動生成されたインスタンス一覧が返されます。
+```json
+[
+  {
+    "id": 2,
+    "title": "毎日の運動",
+    "description": "30分間のウォーキング",
+    "status": "TODO",
+    "priority": "HIGH",
+    "dueDate": "2025-01-02",
+    "parentId": null,
+    "isRepeatable": false,
+    "repeatConfig": null,
+    "originalTodoId": 1,
+    "createdAt": "2025-01-02T00:00:00+09:00",
+    "updatedAt": "2025-01-02T00:00:00+09:00"
+  },
+  {
+    "id": 3,
+    "title": "毎日の運動",
+    "description": "30分間のウォーキング",
+    "status": "DONE",
+    "priority": "HIGH",
+    "dueDate": "2025-01-03",
+    "parentId": null,
+    "isRepeatable": false,
+    "repeatConfig": null,
+    "originalTodoId": 1,
+    "createdAt": "2025-01-03T00:00:00+09:00",
+    "updatedAt": "2025-01-03T08:30:00+09:00"
+  }
+]
+```
+
+### 14. 期限到来した繰り返しTODOのインスタンス生成
+```
+POST /api/v1/todos/repeat/generate
+Authorization: Bearer <JWT_TOKEN>
+```
+
+**レスポンス** (201 Created):
+新しく生成されたTODOインスタンス一覧が返されます。
+```json
+[
+  {
+    "id": 4,
+    "title": "毎日の運動",
+    "description": "30分間のウォーキング",
+    "status": "TODO",
+    "priority": "HIGH",
+    "dueDate": "2025-01-04",
+    "parentId": null,
+    "isRepeatable": false,
+    "repeatConfig": null,
+    "originalTodoId": 1,
+    "createdAt": "2025-01-04T00:00:00+09:00",
+    "updatedAt": "2025-01-04T00:00:00+09:00"
+  }
+]
+```
+
 ## 🔒 ユーザー管理エンドポイント（認証必須）
 
-### 11. ユーザー情報取得
+### 15. ユーザー情報取得
 ```
 GET /api/v1/users/{id}
 Authorization: Bearer <JWT_TOKEN>
@@ -393,7 +594,7 @@ Authorization: Bearer <JWT_TOKEN>
 }
 ```
 
-### 12. ユーザー情報更新
+### 16. ユーザー情報更新
 ```
 PUT /api/v1/users/{id}
 Authorization: Bearer <JWT_TOKEN>
@@ -423,7 +624,7 @@ Authorization: Bearer <JWT_TOKEN>
 }
 ```
 
-### 13. パスワード変更
+### 17. パスワード変更
 ```
 PUT /api/v1/users/{id}/password
 Authorization: Bearer <JWT_TOKEN>
@@ -443,7 +644,7 @@ Authorization: Bearer <JWT_TOKEN>
 **レスポンス** (204 No Content):
 レスポンスボディなし
 
-### 14. ユーザーアカウント削除
+### 18. ユーザーアカウント削除
 ```
 DELETE /api/v1/users/{id}
 Authorization: Bearer <JWT_TOKEN>
@@ -484,6 +685,8 @@ Authorization: Bearer <JWT_TOKEN>
 - `priority`: 任意（デフォルト: MEDIUM）
 - `dueDate`: 任意
 - `parentId`: 任意、親TODO ID
+- `isRepeatable`: 任意（デフォルト: false）
+- `repeatConfig`: 任意、繰り返し設定オブジェクト
 
 ### UpdateTodoRequest
 - `title`: 必須、最大255文字
@@ -492,6 +695,8 @@ Authorization: Bearer <JWT_TOKEN>
 - `priority`: 必須
 - `dueDate`: 任意
 - `parentId`: 任意、親TODO ID
+- `isRepeatable`: 任意（デフォルト: false）
+- `repeatConfig`: 任意、繰り返し設定オブジェクト
 
 ### UpdateUserRequest
 - `username`: 任意、3-20文字
@@ -502,6 +707,13 @@ Authorization: Bearer <JWT_TOKEN>
 ### ChangePasswordRequest
 - `currentPassword`: 必須
 - `newPassword`: 必須、強力なパスワード
+
+### RepeatConfigRequest
+- `repeatType`: 必須、DAILY/WEEKLY/MONTHLY/YEARLY/ONCE
+- `interval`: 任意（デフォルト: 1）、1以上の整数
+- `daysOfWeek`: 任意、1-7の整数配列（WEEKLY時のみ）
+- `dayOfMonth`: 任意、1-31の整数（MONTHLY時のみ）
+- `endDate`: 任意、終了日（YYYY-MM-DD形式）
 
 ## セキュリティ設定
 
@@ -603,9 +815,63 @@ curl -X PUT http://localhost:8080/api/v1/users/1/password \
   }'
 ```
 
+#### 10. 繰り返しTODO作成（要認証）
+```bash
+# 毎日繰り返しTODO
+curl -X POST http://localhost:8080/api/v1/todos \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -d '{
+    "title": "毎日の運動",
+    "description": "30分間のウォーキング",
+    "priority": "HIGH",
+    "dueDate": "2025-01-01",
+    "isRepeatable": true,
+    "repeatConfig": {
+      "repeatType": "DAILY",
+      "interval": 1
+    }
+  }'
+
+# 週次繰り返しTODO（月・水・金）
+curl -X POST http://localhost:8080/api/v1/todos \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -d '{
+    "title": "ジム通い",
+    "description": "筋力トレーニング",
+    "priority": "MEDIUM",
+    "dueDate": "2025-01-06",
+    "isRepeatable": true,
+    "repeatConfig": {
+      "repeatType": "WEEKLY",
+      "interval": 1,
+      "daysOfWeek": [1, 3, 5]
+    }
+  }'
+
+# 月次繰り返しTODO
+curl -X POST http://localhost:8080/api/v1/todos \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -d '{
+    "title": "月次レポート",
+    "description": "月末のレポート作成",
+    "priority": "HIGH",
+    "dueDate": "2025-01-31",
+    "isRepeatable": true,
+    "repeatConfig": {
+      "repeatType": "MONTHLY",
+      "interval": 1,
+      "dayOfMonth": 31,
+      "endDate": "2025-12-31"
+    }
+  }'
+```
+
 ## 🔒 イベント（カレンダー）エンドポイント（認証必須）
 
-### 15. イベント作成
+### 19. イベント作成
 ```
 POST /api/v1/events
 Authorization: Bearer <JWT_TOKEN>
@@ -642,7 +908,7 @@ Authorization: Bearer <JWT_TOKEN>
 }
 ```
 
-### 16. イベント取得（ID指定）
+### 20. イベント取得（ID指定）
 ```
 GET /api/v1/events/{id}
 Authorization: Bearer <JWT_TOKEN>
@@ -668,7 +934,7 @@ Authorization: Bearer <JWT_TOKEN>
 }
 ```
 
-### 17. イベント一覧取得
+### 21. イベント一覧取得
 ```
 GET /api/v1/events
 Authorization: Bearer <JWT_TOKEN>
@@ -708,7 +974,7 @@ Authorization: Bearer <JWT_TOKEN>
 }
 ```
 
-### 18. イベント更新
+### 22. イベント更新
 ```
 PUT /api/v1/events/{id}
 Authorization: Bearer <JWT_TOKEN>
@@ -748,7 +1014,7 @@ Authorization: Bearer <JWT_TOKEN>
 }
 ```
 
-### 19. イベント削除
+### 23. イベント削除
 ```
 DELETE /api/v1/events/{id}
 Authorization: Bearer <JWT_TOKEN>
@@ -762,7 +1028,7 @@ Authorization: Bearer <JWT_TOKEN>
 
 ## 🔒 ノートエンドポイント（認証必須）
 
-### 20. ノート作成
+### 24. ノート作成
 ```
 POST /api/v1/notes
 Authorization: Bearer <JWT_TOKEN>
@@ -789,7 +1055,7 @@ Authorization: Bearer <JWT_TOKEN>
 }
 ```
 
-### 21. ノート取得（ID指定）
+### 25. ノート取得（ID指定）
 ```
 GET /api/v1/notes/{id}
 Authorization: Bearer <JWT_TOKEN>
@@ -810,7 +1076,7 @@ Authorization: Bearer <JWT_TOKEN>
 }
 ```
 
-### 22. ノート一覧取得
+### 26. ノート一覧取得
 ```
 GET /api/v1/notes
 Authorization: Bearer <JWT_TOKEN>
@@ -843,7 +1109,7 @@ Authorization: Bearer <JWT_TOKEN>
 }
 ```
 
-### 23. ノート検索
+### 27. ノート検索
 ```
 GET /api/v1/notes/search
 Authorization: Bearer <JWT_TOKEN>
@@ -867,7 +1133,7 @@ Authorization: Bearer <JWT_TOKEN>
 ]
 ```
 
-### 24. ノート更新
+### 28. ノート更新
 ```
 PUT /api/v1/notes/{id}
 Authorization: Bearer <JWT_TOKEN>
@@ -897,7 +1163,7 @@ Authorization: Bearer <JWT_TOKEN>
 }
 ```
 
-### 25. ノート削除
+### 29. ノート削除
 ```
 DELETE /api/v1/notes/{id}
 Authorization: Bearer <JWT_TOKEN>
@@ -911,7 +1177,7 @@ Authorization: Bearer <JWT_TOKEN>
 
 ## 🔒 分析エンドポイント（認証必須）
 
-### 26. 生産性ダッシュボード取得
+### 30. 生産性ダッシュボード取得
 ```
 GET /api/v1/analytics/dashboard
 Authorization: Bearer <JWT_TOKEN>
@@ -953,7 +1219,7 @@ Authorization: Bearer <JWT_TOKEN>
 }
 ```
 
-### 27. TODOアクティビティ統計
+### 31. TODOアクティビティ統計
 ```
 GET /api/v1/analytics/todos/activity
 Authorization: Bearer <JWT_TOKEN>

--- a/src/main/java/com/zametech/todoapp/application/service/RepeatService.java
+++ b/src/main/java/com/zametech/todoapp/application/service/RepeatService.java
@@ -1,0 +1,219 @@
+package com.zametech.todoapp.application.service;
+
+import com.zametech.todoapp.domain.model.RepeatType;
+import com.zametech.todoapp.domain.model.TodoStatus;
+import com.zametech.todoapp.domain.repository.TodoRepository;
+import com.zametech.todoapp.infrastructure.persistence.entity.TodoEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Service for handling repeatable todos
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class RepeatService {
+
+    private final TodoRepository todoRepository;
+
+    /**
+     * Generate next occurrence of a repeatable todo
+     */
+    @Transactional
+    public TodoEntity generateNextOccurrence(TodoEntity originalTodo) {
+        if (!Boolean.TRUE.equals(originalTodo.getIsRepeatable()) || originalTodo.getRepeatType() == null) {
+            throw new IllegalArgumentException("Todo is not repeatable");
+        }
+
+        LocalDate nextDueDate = calculateNextDueDate(originalTodo);
+        
+        if (nextDueDate == null || isRepeatEndReached(originalTodo, nextDueDate)) {
+            log.debug("Repeat period ended for todo: {}", originalTodo.getId());
+            return null;
+        }
+
+        TodoEntity nextInstance = new TodoEntity(
+                originalTodo.getUserId(),
+                originalTodo.getTitle(),
+                originalTodo.getDescription(),
+                TodoStatus.TODO,
+                originalTodo.getPriority(),
+                nextDueDate,
+                originalTodo.getParentId(),
+                false, // Generated instances are not repeatable themselves
+                null,
+                null,
+                null,
+                null,
+                null,
+                originalTodo.getId() // Reference to original repeatable todo
+        );
+
+        TodoEntity saved = todoRepository.save(nextInstance);
+        log.info("Generated next occurrence {} for repeatable todo {}", saved.getId(), originalTodo.getId());
+        
+        return saved;
+    }
+
+    /**
+     * Calculate the next due date based on repeat configuration
+     */
+    public LocalDate calculateNextDueDate(TodoEntity todo) {
+        if (todo.getDueDate() == null || todo.getRepeatType() == null) {
+            return null;
+        }
+
+        LocalDate currentDueDate = todo.getDueDate();
+        Integer interval = todo.getRepeatInterval() != null ? todo.getRepeatInterval() : 1;
+
+        return switch (todo.getRepeatType()) {
+            case DAILY -> currentDueDate.plusDays(interval);
+            case WEEKLY -> calculateNextWeeklyDate(currentDueDate, todo.getRepeatDaysOfWeek());
+            case MONTHLY -> calculateNextMonthlyDate(currentDueDate, todo.getRepeatDayOfMonth());
+            case YEARLY -> currentDueDate.plusYears(interval);
+            case ONCE -> null; // One-time occurrence, no next date
+        };
+    }
+
+    /**
+     * Calculate next weekly occurrence
+     */
+    private LocalDate calculateNextWeeklyDate(LocalDate currentDate, String daysOfWeekStr) {
+        if (daysOfWeekStr == null || daysOfWeekStr.isEmpty()) {
+            return currentDate.plusWeeks(1);
+        }
+
+        List<Integer> daysOfWeek = Arrays.stream(daysOfWeekStr.split(","))
+                .map(String::trim)
+                .map(Integer::parseInt)
+                .sorted()
+                .collect(Collectors.toList());
+
+        int currentDayOfWeek = currentDate.getDayOfWeek().getValue();
+        
+        // Find next occurrence within the same week
+        for (Integer day : daysOfWeek) {
+            if (day > currentDayOfWeek) {
+                return currentDate.plusDays(day - currentDayOfWeek);
+            }
+        }
+        
+        // If no day found in current week, go to first day of next week
+        Integer firstDay = daysOfWeek.get(0);
+        long daysToAdd = 7 - currentDayOfWeek + firstDay;
+        return currentDate.plusDays(daysToAdd);
+    }
+
+    /**
+     * Calculate next monthly occurrence
+     */
+    private LocalDate calculateNextMonthlyDate(LocalDate currentDate, Integer dayOfMonth) {
+        if (dayOfMonth == null) {
+            return currentDate.plusMonths(1);
+        }
+
+        LocalDate nextMonth = currentDate.plusMonths(1);
+        
+        // Handle case where target day doesn't exist in next month (e.g., Feb 31st -> Feb 28th)
+        int lastDayOfMonth = nextMonth.lengthOfMonth();
+        int targetDay = Math.min(dayOfMonth, lastDayOfMonth);
+        
+        return nextMonth.withDayOfMonth(targetDay);
+    }
+
+    /**
+     * Check if repeat end date has been reached
+     */
+    private boolean isRepeatEndReached(TodoEntity todo, LocalDate nextDate) {
+        return todo.getRepeatEndDate() != null && nextDate.isAfter(todo.getRepeatEndDate());
+    }
+
+    /**
+     * Find all repeatable todos that need next occurrences generated
+     */
+    public List<TodoEntity> findRepeatableTodosNeedingGeneration() {
+        return todoRepository.findByIsRepeatableTrue()
+                .stream()
+                .filter(todo -> todo.getRepeatType() != RepeatType.ONCE)
+                .filter(this::shouldGenerateNextOccurrence)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Check if a repeatable todo should have its next occurrence generated
+     */
+    private boolean shouldGenerateNextOccurrence(TodoEntity todo) {
+        if (todo.getDueDate() == null) {
+            return false;
+        }
+
+        // Check if the current due date has passed or is today
+        LocalDate today = LocalDate.now();
+        if (todo.getDueDate().isAfter(today)) {
+            return false;
+        }
+
+        // Check if next occurrence doesn't already exist
+        LocalDate nextDueDate = calculateNextDueDate(todo);
+        if (nextDueDate == null || isRepeatEndReached(todo, nextDueDate)) {
+            return false;
+        }
+
+        // Check if an instance for the next due date already exists
+        List<TodoEntity> existingInstances = todoRepository.findByOriginalTodoIdAndDueDate(
+                todo.getId(), nextDueDate);
+        
+        return existingInstances.isEmpty();
+    }
+
+    /**
+     * Generate all pending repeat occurrences for a user
+     */
+    @Transactional
+    public List<TodoEntity> generateAllPendingOccurrences(Long userId) {
+        List<TodoEntity> repeatableTodos = todoRepository.findByUserIdAndIsRepeatableTrue(userId);
+        
+        return repeatableTodos.stream()
+                .filter(this::shouldGenerateNextOccurrence)
+                .map(this::generateNextOccurrence)
+                .filter(todo -> todo != null)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Parse days of week string to list
+     */
+    public List<Integer> parseDaysOfWeek(String daysOfWeekStr) {
+        if (daysOfWeekStr == null || daysOfWeekStr.isEmpty()) {
+            return List.of();
+        }
+        
+        return Arrays.stream(daysOfWeekStr.split(","))
+                .map(String::trim)
+                .map(Integer::parseInt)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Format days of week list to string
+     */
+    public String formatDaysOfWeek(List<Integer> daysOfWeek) {
+        if (daysOfWeek == null || daysOfWeek.isEmpty()) {
+            return null;
+        }
+        
+        return daysOfWeek.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining(","));
+    }
+}

--- a/src/main/java/com/zametech/todoapp/application/service/RepeatService.java
+++ b/src/main/java/com/zametech/todoapp/application/service/RepeatService.java
@@ -41,6 +41,15 @@ public class RepeatService {
             log.debug("Repeat period ended for todo: {}", originalTodo.getId());
             return null;
         }
+        
+        // Check if instance already exists for this date
+        List<TodoEntity> existingInstances = todoRepository.findByOriginalTodoIdAndDueDate(
+            originalTodo.getId(), nextDueDate
+        );
+        if (!existingInstances.isEmpty()) {
+            log.debug("Instance already exists for date {} for todo: {}", nextDueDate, originalTodo.getId());
+            return null;
+        }
 
         TodoEntity nextInstance = new TodoEntity(
                 originalTodo.getUserId(),

--- a/src/main/java/com/zametech/todoapp/application/service/TodoService.java
+++ b/src/main/java/com/zametech/todoapp/application/service/TodoService.java
@@ -1,10 +1,12 @@
 package com.zametech.todoapp.application.service;
 
 import com.zametech.todoapp.common.exception.TodoNotFoundException;
+import com.zametech.todoapp.domain.model.RepeatType;
 import com.zametech.todoapp.domain.model.TodoStatus;
 import com.zametech.todoapp.domain.repository.TodoRepository;
 import com.zametech.todoapp.infrastructure.persistence.entity.TodoEntity;
 import com.zametech.todoapp.presentation.dto.request.CreateTodoRequest;
+import com.zametech.todoapp.presentation.dto.request.RepeatConfigRequest;
 import com.zametech.todoapp.presentation.dto.request.UpdateTodoRequest;
 import com.zametech.todoapp.presentation.dto.response.TodoResponse;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,7 @@ public class TodoService {
 
     private final TodoRepository todoRepository;
     private final UserContextService userContextService;
+    private final RepeatService repeatService;
 
     /**
      * TODO作成

--- a/src/main/java/com/zametech/todoapp/application/service/TodoService.java
+++ b/src/main/java/com/zametech/todoapp/application/service/TodoService.java
@@ -52,15 +52,38 @@ public class TodoService {
             }
         }
         
-        TodoEntity todo = new TodoEntity(
-            currentUserId,
-            request.title(),
-            request.description(),
-            TodoStatus.TODO,
-            request.priority(),
-            request.dueDate(),
-            request.parentId()
-        );
+        TodoEntity todo;
+        
+        if (Boolean.TRUE.equals(request.isRepeatable()) && request.repeatConfig() != null) {
+            // 繰り返し設定ありのTODO作成
+            todo = new TodoEntity(
+                currentUserId,
+                request.title(),
+                request.description(),
+                TodoStatus.TODO,
+                request.priority(),
+                request.dueDate(),
+                request.parentId(),
+                request.isRepeatable(),
+                request.repeatConfig().repeatType(),
+                request.repeatConfig().interval(),
+                request.repeatConfig().getDaysOfWeekString(),
+                request.repeatConfig().dayOfMonth(),
+                request.repeatConfig().endDate(),
+                null // originalTodoId - 元となるTODOなのでnull
+            );
+        } else {
+            // 通常のTODO作成
+            todo = new TodoEntity(
+                currentUserId,
+                request.title(),
+                request.description(),
+                TodoStatus.TODO,
+                request.priority(),
+                request.dueDate(),
+                request.parentId()
+            );
+        }
         
         TodoEntity saved = todoRepository.save(todo);
         log.info("Created TODO with id: {} for user: {}", saved.getId(), currentUserId);
@@ -140,12 +163,36 @@ public class TodoService {
             }
         }
         
+        // 基本フィールドの更新
         todo.setTitle(request.title());
         todo.setDescription(request.description());
         todo.setStatus(request.status());
         todo.setPriority(request.priority());
         todo.setDueDate(request.dueDate());
         todo.setParentId(request.parentId());
+        
+        // 繰り返し設定の更新
+        if (Boolean.TRUE.equals(request.isRepeatable()) && request.repeatConfig() != null) {
+            todo.setIsRepeatable(true);
+            todo.setRepeatType(request.repeatConfig().repeatType());
+            todo.setRepeatInterval(request.repeatConfig().interval());
+            todo.setRepeatDaysOfWeek(request.repeatConfig().getDaysOfWeekString());
+            todo.setRepeatDayOfMonth(request.repeatConfig().dayOfMonth());
+            todo.setRepeatEndDate(request.repeatConfig().endDate());
+        } else {
+            // 繰り返し設定を無効化
+            todo.setIsRepeatable(false);
+            todo.setRepeatType(null);
+            todo.setRepeatInterval(null);
+            todo.setRepeatDaysOfWeek(null);
+            todo.setRepeatDayOfMonth(null);
+            todo.setRepeatEndDate(null);
+        }
+        
+        // TODOが完了状態になった場合、次の繰り返しインスタンスを生成
+        if (request.status() == TodoStatus.DONE && Boolean.TRUE.equals(todo.getIsRepeatable()) && todo.getOriginalTodoId() == null) {
+            handleTodoCompletion(todo);
+        }
         
         TodoEntity updated = todoRepository.save(todo);
         log.info("Updated TODO with id: {} for user: {}", updated.getId(), currentUserId);
@@ -191,5 +238,80 @@ public class TodoService {
         return childTasks.stream()
             .map(TodoResponse::from)
             .toList();
+    }
+    
+    /**
+     * 繰り返し可能なTODO一覧取得
+     */
+    public List<TodoResponse> getRepeatableTodos() {
+        log.debug("Getting all repeatable TODOs for current user");
+        
+        Long currentUserId = userContextService.getCurrentUserId();
+        List<TodoEntity> repeatableTodos = todoRepository.findByUserIdAndIsRepeatableTrue(currentUserId);
+        return repeatableTodos.stream()
+            .map(TodoResponse::from)
+            .toList();
+    }
+    
+    /**
+     * 特定の繰り返しTODOから生成されたインスタンス一覧を取得
+     */
+    public List<TodoResponse> getRepeatInstances(Long originalTodoId) {
+        log.debug("Getting repeat instances for original TODO id: {}", originalTodoId);
+        
+        // Verify original TODO exists and user has access
+        TodoEntity originalTodo = todoRepository.findById(originalTodoId)
+            .orElseThrow(() -> new TodoNotFoundException(originalTodoId));
+        
+        Long currentUserId = userContextService.getCurrentUserId();
+        if (!originalTodo.getUserId().equals(currentUserId)) {
+            throw new AccessDeniedException("Access denied to TODO with id: " + originalTodoId);
+        }
+        
+        List<TodoEntity> instances = todoRepository.findByOriginalTodoId(originalTodoId);
+        return instances.stream()
+            .map(TodoResponse::from)
+            .toList();
+    }
+    
+    /**
+     * 期限到来した繰り返しTODOの新しいインスタンスを生成
+     */
+    @Transactional
+    public List<TodoResponse> generatePendingRepeatInstances() {
+        log.debug("Generating pending repeat instances for current user");
+        
+        Long currentUserId = userContextService.getCurrentUserId();
+        List<TodoEntity> newInstances = repeatService.generateAllPendingOccurrences(currentUserId);
+        
+        List<TodoEntity> savedInstances = newInstances.stream()
+            .map(todoRepository::save)
+            .toList();
+        
+        log.info("Generated {} new repeat instances for user: {}", savedInstances.size(), currentUserId);
+        
+        return savedInstances.stream()
+            .map(TodoResponse::from)
+            .toList();
+    }
+    
+    /**
+     * TODO完了時の繰り返し処理
+     */
+    private void handleTodoCompletion(TodoEntity completedTodo) {
+        if (!Boolean.TRUE.equals(completedTodo.getIsRepeatable()) || completedTodo.getOriginalTodoId() != null) {
+            return; // 繰り返し設定がないか、すでに生成されたインスタンスの場合は何もしない
+        }
+        
+        try {
+            TodoEntity nextInstance = repeatService.generateNextOccurrence(completedTodo);
+            if (nextInstance != null) {
+                todoRepository.save(nextInstance);
+                log.info("Generated next occurrence for completed TODO id: {}", completedTodo.getId());
+            }
+        } catch (Exception e) {
+            log.error("Failed to generate next occurrence for TODO id: {}", completedTodo.getId(), e);
+            // エラーをログに記録するが、元のTODOの更新は続行
+        }
     }
 }

--- a/src/main/java/com/zametech/todoapp/domain/model/RepeatConfig.java
+++ b/src/main/java/com/zametech/todoapp/domain/model/RepeatConfig.java
@@ -1,0 +1,42 @@
+package com.zametech.todoapp.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Configuration for repeatable todos
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RepeatConfig {
+    private RepeatType repeatType;
+    private Integer interval;           // e.g., every 2 weeks
+    private List<Integer> daysOfWeek;   // for weekly: 1=Monday, 7=Sunday
+    private Integer dayOfMonth;         // for monthly: 1-31
+    private LocalDate endDate;          // null means no end date
+    
+    public static RepeatConfig daily(Integer interval, LocalDate endDate) {
+        return new RepeatConfig(RepeatType.DAILY, interval, null, null, endDate);
+    }
+    
+    public static RepeatConfig weekly(List<Integer> daysOfWeek, LocalDate endDate) {
+        return new RepeatConfig(RepeatType.WEEKLY, 1, daysOfWeek, null, endDate);
+    }
+    
+    public static RepeatConfig monthly(Integer dayOfMonth, LocalDate endDate) {
+        return new RepeatConfig(RepeatType.MONTHLY, 1, null, dayOfMonth, endDate);
+    }
+    
+    public static RepeatConfig yearly(LocalDate endDate) {
+        return new RepeatConfig(RepeatType.YEARLY, 1, null, null, endDate);
+    }
+    
+    public static RepeatConfig once() {
+        return new RepeatConfig(RepeatType.ONCE, null, null, null, null);
+    }
+}

--- a/src/main/java/com/zametech/todoapp/domain/model/RepeatType.java
+++ b/src/main/java/com/zametech/todoapp/domain/model/RepeatType.java
@@ -1,0 +1,12 @@
+package com.zametech.todoapp.domain.model;
+
+/**
+ * Enumeration for TODO repeat types
+ */
+public enum RepeatType {
+    DAILY,      // Repeat daily
+    WEEKLY,     // Repeat weekly on specified days
+    MONTHLY,    // Repeat monthly on the same day
+    YEARLY,     // Repeat yearly on the same date
+    ONCE        // One-time occurrence (specific date)
+}

--- a/src/main/java/com/zametech/todoapp/domain/model/Todo.java
+++ b/src/main/java/com/zametech/todoapp/domain/model/Todo.java
@@ -22,4 +22,13 @@ public class Todo {
     private Long parentId;  // Parent task ID for hierarchical structure
     private ZonedDateTime createdAt;
     private ZonedDateTime updatedAt;
+    
+    // Repeat fields
+    private Boolean isRepeatable;
+    private RepeatType repeatType;
+    private Integer repeatInterval;
+    private String repeatDaysOfWeek;  // Comma-separated string: "1,3,5"
+    private Integer repeatDayOfMonth;
+    private LocalDate repeatEndDate;
+    private Long originalTodoId;  // Reference to original repeatable todo
 }

--- a/src/main/java/com/zametech/todoapp/domain/repository/TodoRepository.java
+++ b/src/main/java/com/zametech/todoapp/domain/repository/TodoRepository.java
@@ -74,4 +74,24 @@ public interface TodoRepository {
      * 親タスクIDで子タスクを検索する
      */
     List<TodoEntity> findByParentId(Long parentId);
+    
+    /**
+     * 繰り返し可能なTODOを検索する
+     */
+    List<TodoEntity> findByIsRepeatableTrue();
+    
+    /**
+     * ユーザーIDで繰り返し可能なTODOを検索する
+     */
+    List<TodoEntity> findByUserIdAndIsRepeatableTrue(Long userId);
+    
+    /**
+     * 元TODOIDと期限日でTODOを検索する（繰り返しインスタンス検索用）
+     */
+    List<TodoEntity> findByOriginalTodoIdAndDueDate(Long originalTodoId, LocalDate dueDate);
+    
+    /**
+     * 元TODOIDで生成されたインスタンスを検索する
+     */
+    List<TodoEntity> findByOriginalTodoId(Long originalTodoId);
 }

--- a/src/main/java/com/zametech/todoapp/infrastructure/persistence/entity/TodoEntity.java
+++ b/src/main/java/com/zametech/todoapp/infrastructure/persistence/entity/TodoEntity.java
@@ -2,6 +2,7 @@ package com.zametech.todoapp.infrastructure.persistence.entity;
 
 import com.zametech.todoapp.domain.model.TodoPriority;
 import com.zametech.todoapp.domain.model.TodoStatus;
+import com.zametech.todoapp.domain.model.RepeatType;
 import jakarta.persistence.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -51,6 +52,29 @@ public class TodoEntity {
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
     private java.util.List<TodoEntity> children = new java.util.ArrayList<>();
 
+    // Repeat fields
+    @Column(name = "is_repeatable")
+    private Boolean isRepeatable = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "repeat_type", length = 50)
+    private RepeatType repeatType;
+
+    @Column(name = "repeat_interval")
+    private Integer repeatInterval;
+
+    @Column(name = "repeat_days_of_week", length = 20)
+    private String repeatDaysOfWeek;
+
+    @Column(name = "repeat_day_of_month")
+    private Integer repeatDayOfMonth;
+
+    @Column(name = "repeat_end_date")
+    private LocalDate repeatEndDate;
+
+    @Column(name = "original_todo_id")
+    private Long originalTodoId;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private ZonedDateTime createdAt;
@@ -77,6 +101,21 @@ public class TodoEntity {
                       TodoPriority priority, LocalDate dueDate, Long parentId) {
         this(userId, title, description, status, priority, dueDate);
         this.parentId = parentId;
+    }
+
+    public TodoEntity(Long userId, String title, String description, TodoStatus status,
+                      TodoPriority priority, LocalDate dueDate, Long parentId,
+                      Boolean isRepeatable, RepeatType repeatType, Integer repeatInterval,
+                      String repeatDaysOfWeek, Integer repeatDayOfMonth, LocalDate repeatEndDate,
+                      Long originalTodoId) {
+        this(userId, title, description, status, priority, dueDate, parentId);
+        this.isRepeatable = isRepeatable;
+        this.repeatType = repeatType;
+        this.repeatInterval = repeatInterval;
+        this.repeatDaysOfWeek = repeatDaysOfWeek;
+        this.repeatDayOfMonth = repeatDayOfMonth;
+        this.repeatEndDate = repeatEndDate;
+        this.originalTodoId = originalTodoId;
     }
 
     // Getters and Setters
@@ -174,6 +213,62 @@ public class TodoEntity {
 
     public void setChildren(java.util.List<TodoEntity> children) {
         this.children = children;
+    }
+
+    public Boolean getIsRepeatable() {
+        return isRepeatable;
+    }
+
+    public void setIsRepeatable(Boolean isRepeatable) {
+        this.isRepeatable = isRepeatable;
+    }
+
+    public RepeatType getRepeatType() {
+        return repeatType;
+    }
+
+    public void setRepeatType(RepeatType repeatType) {
+        this.repeatType = repeatType;
+    }
+
+    public Integer getRepeatInterval() {
+        return repeatInterval;
+    }
+
+    public void setRepeatInterval(Integer repeatInterval) {
+        this.repeatInterval = repeatInterval;
+    }
+
+    public String getRepeatDaysOfWeek() {
+        return repeatDaysOfWeek;
+    }
+
+    public void setRepeatDaysOfWeek(String repeatDaysOfWeek) {
+        this.repeatDaysOfWeek = repeatDaysOfWeek;
+    }
+
+    public Integer getRepeatDayOfMonth() {
+        return repeatDayOfMonth;
+    }
+
+    public void setRepeatDayOfMonth(Integer repeatDayOfMonth) {
+        this.repeatDayOfMonth = repeatDayOfMonth;
+    }
+
+    public LocalDate getRepeatEndDate() {
+        return repeatEndDate;
+    }
+
+    public void setRepeatEndDate(LocalDate repeatEndDate) {
+        this.repeatEndDate = repeatEndDate;
+    }
+
+    public Long getOriginalTodoId() {
+        return originalTodoId;
+    }
+
+    public void setOriginalTodoId(Long originalTodoId) {
+        this.originalTodoId = originalTodoId;
     }
 
     @Override

--- a/src/main/java/com/zametech/todoapp/infrastructure/persistence/repository/TodoJpaRepository.java
+++ b/src/main/java/com/zametech/todoapp/infrastructure/persistence/repository/TodoJpaRepository.java
@@ -65,4 +65,24 @@ public interface TodoJpaRepository extends JpaRepository<TodoEntity, Long> {
      * 親タスクIDで子タスクを検索する
      */
     List<TodoEntity> findByParentIdOrderByCreatedAtDesc(Long parentId);
+    
+    /**
+     * 繰り返し可能なTODOを検索する
+     */
+    List<TodoEntity> findByIsRepeatableTrueOrderByCreatedAtDesc();
+    
+    /**
+     * ユーザーIDで繰り返し可能なTODOを検索する
+     */
+    List<TodoEntity> findByUserIdAndIsRepeatableTrueOrderByCreatedAtDesc(Long userId);
+    
+    /**
+     * 元TODOIDと期限日でTODOを検索する
+     */
+    List<TodoEntity> findByOriginalTodoIdAndDueDate(Long originalTodoId, LocalDate dueDate);
+    
+    /**
+     * 元TODOIDで生成されたインスタンスを検索する
+     */
+    List<TodoEntity> findByOriginalTodoIdOrderByCreatedAtDesc(Long originalTodoId);
 }

--- a/src/main/java/com/zametech/todoapp/infrastructure/persistence/repository/TodoRepositoryImpl.java
+++ b/src/main/java/com/zametech/todoapp/infrastructure/persistence/repository/TodoRepositoryImpl.java
@@ -81,4 +81,24 @@ public class TodoRepositoryImpl implements TodoRepository {
     public List<TodoEntity> findByParentId(Long parentId) {
         return todoJpaRepository.findByParentIdOrderByCreatedAtDesc(parentId);
     }
+    
+    @Override
+    public List<TodoEntity> findByIsRepeatableTrue() {
+        return todoJpaRepository.findByIsRepeatableTrueOrderByCreatedAtDesc();
+    }
+    
+    @Override
+    public List<TodoEntity> findByUserIdAndIsRepeatableTrue(Long userId) {
+        return todoJpaRepository.findByUserIdAndIsRepeatableTrueOrderByCreatedAtDesc(userId);
+    }
+    
+    @Override
+    public List<TodoEntity> findByOriginalTodoIdAndDueDate(Long originalTodoId, LocalDate dueDate) {
+        return todoJpaRepository.findByOriginalTodoIdAndDueDate(originalTodoId, dueDate);
+    }
+    
+    @Override
+    public List<TodoEntity> findByOriginalTodoId(Long originalTodoId) {
+        return todoJpaRepository.findByOriginalTodoIdOrderByCreatedAtDesc(originalTodoId);
+    }
 }

--- a/src/main/java/com/zametech/todoapp/presentation/controller/TodoController.java
+++ b/src/main/java/com/zametech/todoapp/presentation/controller/TodoController.java
@@ -102,4 +102,34 @@ public class TodoController {
         List<TodoResponse> response = todoService.getChildTasks(parentId);
         return ResponseEntity.ok(response);
     }
+    
+    /**
+     * 繰り返し可能なTODO一覧取得
+     */
+    @GetMapping("/repeatable")
+    public ResponseEntity<List<TodoResponse>> getRepeatableTodos() {
+        log.info("GET /api/v1/todos/repeatable - Getting repeatable TODOs");
+        List<TodoResponse> response = todoService.getRepeatableTodos();
+        return ResponseEntity.ok(response);
+    }
+    
+    /**
+     * 特定の繰り返しTODOから生成されたインスタンス一覧を取得
+     */
+    @GetMapping("/{originalTodoId}/instances")
+    public ResponseEntity<List<TodoResponse>> getRepeatInstances(@PathVariable Long originalTodoId) {
+        log.info("GET /api/v1/todos/{}/instances - Getting repeat instances", originalTodoId);
+        List<TodoResponse> response = todoService.getRepeatInstances(originalTodoId);
+        return ResponseEntity.ok(response);
+    }
+    
+    /**
+     * 期限到来した繰り返しTODOの新しいインスタンスを生成
+     */
+    @PostMapping("/repeat/generate")
+    public ResponseEntity<List<TodoResponse>> generatePendingRepeatInstances() {
+        log.info("POST /api/v1/todos/repeat/generate - Generating pending repeat instances");
+        List<TodoResponse> response = todoService.generatePendingRepeatInstances();
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
 }

--- a/src/main/java/com/zametech/todoapp/presentation/dto/request/CreateTodoRequest.java
+++ b/src/main/java/com/zametech/todoapp/presentation/dto/request/CreateTodoRequest.java
@@ -1,6 +1,7 @@
 package com.zametech.todoapp.presentation.dto.request;
 
 import com.zametech.todoapp.domain.model.TodoPriority;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -21,12 +22,28 @@ public record CreateTodoRequest(
     
     LocalDate dueDate,
     
-    Long parentId
+    Long parentId,
+    
+    Boolean isRepeatable,
+    
+    @Valid
+    RepeatConfigRequest repeatConfig
 ) {
     public CreateTodoRequest {
         // デフォルト値の設定
         if (priority == null) {
             priority = TodoPriority.MEDIUM;
+        }
+        if (isRepeatable == null) {
+            isRepeatable = false;
+        }
+        
+        // 繰り返し設定の妥当性チェック
+        if (Boolean.TRUE.equals(isRepeatable) && repeatConfig == null) {
+            throw new IllegalArgumentException("繰り返し設定が有効な場合、繰り返し設定は必須です");
+        }
+        if (Boolean.FALSE.equals(isRepeatable) && repeatConfig != null) {
+            throw new IllegalArgumentException("繰り返し設定が無効な場合、繰り返し設定は指定できません");
         }
     }
 }

--- a/src/main/java/com/zametech/todoapp/presentation/dto/request/RepeatConfigRequest.java
+++ b/src/main/java/com/zametech/todoapp/presentation/dto/request/RepeatConfigRequest.java
@@ -18,8 +18,7 @@ public record RepeatConfigRequest(
     @Min(value = 1, message = "間隔は1以上で指定してください")
     Integer interval,
     
-    @Pattern(regexp = "^[1-7](,[1-7])*$", message = "曜日は1-7の範囲でカンマ区切りで指定してください")
-    String daysOfWeek,
+    List<Integer> daysOfWeek,
     
     @Min(value = 1, message = "日付は1以上で指定してください")
     Integer dayOfMonth,
@@ -35,16 +34,15 @@ public record RepeatConfigRequest(
     }
     
     /**
-     * 曜日文字列をリストに変換
+     * 曜日リストを文字列に変換（データベース保存用）
      */
-    public List<Integer> getDaysOfWeekList() {
+    public String getDaysOfWeekString() {
         if (daysOfWeek == null || daysOfWeek.isEmpty()) {
-            return List.of();
+            return null;
         }
-        return List.of(daysOfWeek.split(","))
-                .stream()
-                .map(String::trim)
-                .map(Integer::parseInt)
-                .toList();
+        return daysOfWeek.stream()
+                .map(String::valueOf)
+                .reduce((a, b) -> a + "," + b)
+                .orElse(null);
     }
 }

--- a/src/main/java/com/zametech/todoapp/presentation/dto/request/RepeatConfigRequest.java
+++ b/src/main/java/com/zametech/todoapp/presentation/dto/request/RepeatConfigRequest.java
@@ -1,0 +1,50 @@
+package com.zametech.todoapp.presentation.dto.request;
+
+import com.zametech.todoapp.domain.model.RepeatType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 繰り返し設定リクエスト
+ */
+public record RepeatConfigRequest(
+    @NotNull(message = "繰り返しタイプは必須です")
+    RepeatType repeatType,
+    
+    @Min(value = 1, message = "間隔は1以上で指定してください")
+    Integer interval,
+    
+    @Pattern(regexp = "^[1-7](,[1-7])*$", message = "曜日は1-7の範囲でカンマ区切りで指定してください")
+    String daysOfWeek,
+    
+    @Min(value = 1, message = "日付は1以上で指定してください")
+    Integer dayOfMonth,
+    
+    LocalDate endDate
+) {
+    public RepeatConfigRequest {
+        // デフォルト値の設定
+        if (interval == null && (repeatType == RepeatType.DAILY || repeatType == RepeatType.WEEKLY || 
+                                 repeatType == RepeatType.MONTHLY || repeatType == RepeatType.YEARLY)) {
+            interval = 1;
+        }
+    }
+    
+    /**
+     * 曜日文字列をリストに変換
+     */
+    public List<Integer> getDaysOfWeekList() {
+        if (daysOfWeek == null || daysOfWeek.isEmpty()) {
+            return List.of();
+        }
+        return List.of(daysOfWeek.split(","))
+                .stream()
+                .map(String::trim)
+                .map(Integer::parseInt)
+                .toList();
+    }
+}

--- a/src/main/java/com/zametech/todoapp/presentation/dto/request/UpdateTodoRequest.java
+++ b/src/main/java/com/zametech/todoapp/presentation/dto/request/UpdateTodoRequest.java
@@ -2,6 +2,7 @@ package com.zametech.todoapp.presentation.dto.request;
 
 import com.zametech.todoapp.domain.model.TodoPriority;
 import com.zametech.todoapp.domain.model.TodoStatus;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -27,5 +28,20 @@ public record UpdateTodoRequest(
     
     LocalDate dueDate,
     
-    Long parentId
-) {}
+    Long parentId,
+    
+    Boolean isRepeatable,
+    
+    @Valid
+    RepeatConfigRequest repeatConfig
+) {
+    public UpdateTodoRequest {
+        // 繰り返し設定の妥当性チェック
+        if (Boolean.TRUE.equals(isRepeatable) && repeatConfig == null) {
+            throw new IllegalArgumentException("繰り返し設定が有効な場合、繰り返し設定は必須です");
+        }
+        if (Boolean.FALSE.equals(isRepeatable) && repeatConfig != null) {
+            throw new IllegalArgumentException("繰り返し設定が無効な場合、繰り返し設定は指定できません");
+        }
+    }
+}

--- a/src/main/java/com/zametech/todoapp/presentation/dto/response/RepeatConfigResponse.java
+++ b/src/main/java/com/zametech/todoapp/presentation/dto/response/RepeatConfigResponse.java
@@ -1,0 +1,44 @@
+package com.zametech.todoapp.presentation.dto.response;
+
+import com.zametech.todoapp.domain.model.RepeatType;
+import com.zametech.todoapp.infrastructure.persistence.entity.TodoEntity;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 繰り返し設定レスポンス
+ */
+public record RepeatConfigResponse(
+    RepeatType repeatType,
+    Integer interval,
+    List<Integer> daysOfWeek,
+    Integer dayOfMonth,
+    LocalDate endDate
+) {
+    /**
+     * TodoEntityから生成
+     */
+    public static RepeatConfigResponse from(TodoEntity entity) {
+        if (!Boolean.TRUE.equals(entity.getIsRepeatable()) || entity.getRepeatType() == null) {
+            return null;
+        }
+        
+        List<Integer> daysOfWeek = null;
+        if (entity.getRepeatDaysOfWeek() != null && !entity.getRepeatDaysOfWeek().isEmpty()) {
+            daysOfWeek = Arrays.stream(entity.getRepeatDaysOfWeek().split(","))
+                    .map(String::trim)
+                    .map(Integer::parseInt)
+                    .toList();
+        }
+        
+        return new RepeatConfigResponse(
+                entity.getRepeatType(),
+                entity.getRepeatInterval(),
+                daysOfWeek,
+                entity.getRepeatDayOfMonth(),
+                entity.getRepeatEndDate()
+        );
+    }
+}

--- a/src/main/java/com/zametech/todoapp/presentation/dto/response/TodoResponse.java
+++ b/src/main/java/com/zametech/todoapp/presentation/dto/response/TodoResponse.java
@@ -18,6 +18,9 @@ public record TodoResponse(
     TodoPriority priority,
     LocalDate dueDate,
     Long parentId,
+    Boolean isRepeatable,
+    RepeatConfigResponse repeatConfig,
+    Long originalTodoId,
     ZonedDateTime createdAt,
     ZonedDateTime updatedAt
 ) {
@@ -33,6 +36,9 @@ public record TodoResponse(
             entity.getPriority(),
             entity.getDueDate(),
             entity.getParentId(),
+            entity.getIsRepeatable(),
+            RepeatConfigResponse.from(entity),
+            entity.getOriginalTodoId(),
             entity.getCreatedAt(),
             entity.getUpdatedAt()
         );

--- a/src/main/resources/db/migration/V8__add_repeat_fields_to_todos.sql
+++ b/src/main/resources/db/migration/V8__add_repeat_fields_to_todos.sql
@@ -1,0 +1,47 @@
+-- Add repeat fields to todos table for repeatable functionality
+ALTER TABLE todos 
+    ADD COLUMN is_repeatable BOOLEAN DEFAULT FALSE,
+    ADD COLUMN repeat_type VARCHAR(50),
+    ADD COLUMN repeat_interval INTEGER DEFAULT 1,
+    ADD COLUMN repeat_days_of_week VARCHAR(20),
+    ADD COLUMN repeat_day_of_month INTEGER,
+    ADD COLUMN repeat_end_date DATE,
+    ADD COLUMN original_todo_id BIGINT;
+
+-- Add check constraints for repeat_type
+ALTER TABLE todos ADD CONSTRAINT chk_repeat_type
+    CHECK (repeat_type IS NULL OR repeat_type IN ('DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY', 'ONCE'));
+
+-- Add check constraint for repeat_interval (must be positive)
+ALTER TABLE todos ADD CONSTRAINT chk_repeat_interval
+    CHECK (repeat_interval IS NULL OR repeat_interval > 0);
+
+-- Add check constraint for repeat_days_of_week (comma-separated numbers 1-7)
+ALTER TABLE todos ADD CONSTRAINT chk_repeat_days_of_week
+    CHECK (repeat_days_of_week IS NULL OR repeat_days_of_week ~ '^[1-7](,[1-7])*$');
+
+-- Add check constraint for repeat_day_of_month (1-31)
+ALTER TABLE todos ADD CONSTRAINT chk_repeat_day_of_month
+    CHECK (repeat_day_of_month IS NULL OR (repeat_day_of_month >= 1 AND repeat_day_of_month <= 31));
+
+-- Add foreign key constraint for original_todo_id
+ALTER TABLE todos
+    ADD CONSTRAINT fk_todo_original
+        FOREIGN KEY (original_todo_id)
+            REFERENCES todos(id)
+            ON DELETE CASCADE;
+
+-- Add indexes for better query performance
+CREATE INDEX idx_todos_is_repeatable ON todos(is_repeatable);
+CREATE INDEX idx_todos_repeat_type ON todos(repeat_type);
+CREATE INDEX idx_todos_original_todo_id ON todos(original_todo_id);
+CREATE INDEX idx_todos_repeat_end_date ON todos(repeat_end_date);
+
+-- Add comments for documentation
+COMMENT ON COLUMN todos.is_repeatable IS 'Whether this todo has repeat settings';
+COMMENT ON COLUMN todos.repeat_type IS 'Type of repetition: DAILY, WEEKLY, MONTHLY, YEARLY, ONCE';
+COMMENT ON COLUMN todos.repeat_interval IS 'Interval for repetition (e.g., every 2 weeks)';
+COMMENT ON COLUMN todos.repeat_days_of_week IS 'Days of week for weekly repeat (1=Monday, 7=Sunday)';
+COMMENT ON COLUMN todos.repeat_day_of_month IS 'Day of month for monthly repeat (1-31)';
+COMMENT ON COLUMN todos.repeat_end_date IS 'End date for repetition (null means no end)';
+COMMENT ON COLUMN todos.original_todo_id IS 'Reference to the original repeatable todo';

--- a/src/test/java/com/zametech/todoapp/application/service/RepeatServiceTest.java
+++ b/src/test/java/com/zametech/todoapp/application/service/RepeatServiceTest.java
@@ -1,0 +1,266 @@
+package com.zametech.todoapp.application.service;
+
+import com.zametech.todoapp.domain.model.RepeatType;
+import com.zametech.todoapp.domain.model.TodoPriority;
+import com.zametech.todoapp.domain.model.TodoStatus;
+import com.zametech.todoapp.domain.repository.TodoRepository;
+import com.zametech.todoapp.infrastructure.persistence.entity.TodoEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RepeatServiceTest {
+
+    @Mock
+    private TodoRepository todoRepository;
+
+    @InjectMocks
+    private RepeatService repeatService;
+
+    private TodoEntity createRepeatableTodo(RepeatType repeatType, Integer interval, String daysOfWeek, 
+                                          Integer dayOfMonth, LocalDate dueDate, LocalDate endDate) {
+        return new TodoEntity(
+            1L, // userId
+            "Test Repeatable TODO",
+            "Test Description",
+            TodoStatus.TODO,
+            TodoPriority.MEDIUM,
+            dueDate,
+            null, // parentId
+            true, // isRepeatable
+            repeatType,
+            interval,
+            daysOfWeek,
+            dayOfMonth,
+            endDate,
+            null // originalTodoId
+        );
+    }
+
+    @Test
+    void testCalculateNextDueDate_Daily() {
+        // Given
+        TodoEntity dailyTodo = createRepeatableTodo(
+            RepeatType.DAILY, 1, null, null, 
+            LocalDate.of(2025, 1, 1), null
+        );
+
+        // When
+        LocalDate nextDueDate = repeatService.calculateNextDueDate(dailyTodo);
+
+        // Then
+        assertThat(nextDueDate).isEqualTo(LocalDate.of(2025, 1, 2));
+    }
+
+    @Test
+    void testCalculateNextDueDate_DailyWithInterval() {
+        // Given
+        TodoEntity dailyTodo = createRepeatableTodo(
+            RepeatType.DAILY, 3, null, null, 
+            LocalDate.of(2025, 1, 1), null
+        );
+
+        // When
+        LocalDate nextDueDate = repeatService.calculateNextDueDate(dailyTodo);
+
+        // Then
+        assertThat(nextDueDate).isEqualTo(LocalDate.of(2025, 1, 4));
+    }
+
+    @Test
+    void testCalculateNextDueDate_Weekly() {
+        // Given - 月曜日 (1) に設定
+        TodoEntity weeklyTodo = createRepeatableTodo(
+            RepeatType.WEEKLY, 1, "1", null, 
+            LocalDate.of(2025, 1, 6), null // 2025-01-06は月曜日
+        );
+
+        // When
+        LocalDate nextDueDate = repeatService.calculateNextDueDate(weeklyTodo);
+
+        // Then
+        assertThat(nextDueDate).isEqualTo(LocalDate.of(2025, 1, 13)); // 次の月曜日
+    }
+
+    @Test
+    void testCalculateNextDueDate_Weekly_MultipleDays() {
+        // Given - 月曜日 (1) と金曜日 (5) に設定
+        TodoEntity weeklyTodo = createRepeatableTodo(
+            RepeatType.WEEKLY, 1, "1,5", null, 
+            LocalDate.of(2025, 1, 6), null // 2025-01-06は月曜日
+        );
+
+        // When
+        LocalDate nextDueDate = repeatService.calculateNextDueDate(weeklyTodo);
+
+        // Then
+        assertThat(nextDueDate).isEqualTo(LocalDate.of(2025, 1, 10)); // 次の金曜日
+    }
+
+    @Test
+    void testCalculateNextDueDate_Monthly() {
+        // Given - 毎月15日
+        TodoEntity monthlyTodo = createRepeatableTodo(
+            RepeatType.MONTHLY, 1, null, 15, 
+            LocalDate.of(2025, 1, 15), null
+        );
+
+        // When
+        LocalDate nextDueDate = repeatService.calculateNextDueDate(monthlyTodo);
+
+        // Then
+        assertThat(nextDueDate).isEqualTo(LocalDate.of(2025, 2, 15));
+    }
+
+    @Test
+    void testCalculateNextDueDate_Monthly_LastDayOfMonth() {
+        // Given - 毎月31日 (2月は28日になる)
+        TodoEntity monthlyTodo = createRepeatableTodo(
+            RepeatType.MONTHLY, 1, null, 31, 
+            LocalDate.of(2025, 1, 31), null
+        );
+
+        // When
+        LocalDate nextDueDate = repeatService.calculateNextDueDate(monthlyTodo);
+
+        // Then
+        assertThat(nextDueDate).isEqualTo(LocalDate.of(2025, 2, 28)); // 2月は28日まで
+    }
+
+    @Test
+    void testCalculateNextDueDate_Yearly() {
+        // Given
+        TodoEntity yearlyTodo = createRepeatableTodo(
+            RepeatType.YEARLY, 1, null, null, 
+            LocalDate.of(2025, 1, 1), null
+        );
+
+        // When
+        LocalDate nextDueDate = repeatService.calculateNextDueDate(yearlyTodo);
+
+        // Then
+        assertThat(nextDueDate).isEqualTo(LocalDate.of(2026, 1, 1));
+    }
+
+    @Test
+    void testCalculateNextDueDate_Once() {
+        // Given
+        TodoEntity onceTodo = createRepeatableTodo(
+            RepeatType.ONCE, null, null, null, 
+            LocalDate.of(2025, 1, 1), null
+        );
+
+        // When
+        LocalDate nextDueDate = repeatService.calculateNextDueDate(onceTodo);
+
+        // Then
+        assertThat(nextDueDate).isNull(); // ONCE は繰り返しなし
+    }
+
+    @Test
+    void testGenerateNextOccurrence() {
+        // Given
+        TodoEntity originalTodo = createRepeatableTodo(
+            RepeatType.DAILY, 1, null, null, 
+            LocalDate.of(2025, 1, 1), null
+        );
+        originalTodo.setId(1L);
+
+        when(todoRepository.findByOriginalTodoIdAndDueDate(1L, LocalDate.of(2025, 1, 2))).thenReturn(List.of());
+        
+        // Mock the save operation to return the entity with an ID
+        when(todoRepository.save(any(TodoEntity.class))).thenAnswer(invocation -> {
+            TodoEntity entity = invocation.getArgument(0);
+            entity.setId(2L); // Simulate generated ID
+            return entity;
+        });
+
+        // When
+        TodoEntity nextOccurrence = repeatService.generateNextOccurrence(originalTodo);
+
+        // Then
+        assertThat(nextOccurrence).isNotNull();
+        assertThat(nextOccurrence.getId()).isEqualTo(2L);
+        assertThat(nextOccurrence.getTitle()).isEqualTo("Test Repeatable TODO");
+        assertThat(nextOccurrence.getDueDate()).isEqualTo(LocalDate.of(2025, 1, 2));
+        assertThat(nextOccurrence.getOriginalTodoId()).isEqualTo(1L);
+        assertThat(nextOccurrence.getIsRepeatable()).isFalse(); // 生成されたインスタンスは繰り返し不可
+    }
+
+    @Test
+    void testGenerateNextOccurrence_AlreadyExists() {
+        // Given
+        TodoEntity originalTodo = createRepeatableTodo(
+            RepeatType.DAILY, 1, null, null, 
+            LocalDate.of(2025, 1, 1), null
+        );
+        originalTodo.setId(1L);
+
+        // すでに存在するインスタンス
+        TodoEntity existingInstance = new TodoEntity();
+        when(todoRepository.findByOriginalTodoIdAndDueDate(1L, LocalDate.of(2025, 1, 2)))
+            .thenReturn(List.of(existingInstance));
+
+        // When
+        TodoEntity nextOccurrence = repeatService.generateNextOccurrence(originalTodo);
+
+        // Then
+        assertThat(nextOccurrence).isNull(); // すでに存在する場合はnull
+    }
+
+    @Test
+    void testGenerateNextOccurrence_BeyondEndDate() {
+        // Given
+        TodoEntity originalTodo = createRepeatableTodo(
+            RepeatType.DAILY, 1, null, null, 
+            LocalDate.of(2025, 1, 1), 
+            LocalDate.of(2025, 1, 1) // 終了日が今日
+        );
+        originalTodo.setId(1L);
+
+        // When
+        TodoEntity nextOccurrence = repeatService.generateNextOccurrence(originalTodo);
+
+        // Then
+        assertThat(nextOccurrence).isNull(); // 終了日を過ぎているのでnull
+    }
+
+    @Test
+    void testGenerateAllPendingOccurrences() {
+        // Given
+        Long userId = 1L;
+        TodoEntity repeatableTodo = createRepeatableTodo(
+            RepeatType.DAILY, 1, null, null, 
+            LocalDate.of(2025, 1, 1), null
+        );
+        repeatableTodo.setId(1L);
+
+        when(todoRepository.findByUserIdAndIsRepeatableTrue(userId)).thenReturn(List.of(repeatableTodo));
+        when(todoRepository.findByOriginalTodoIdAndDueDate(1L, LocalDate.of(2025, 1, 2))).thenReturn(List.of());
+        
+        // Mock the save operation to return the entity with an ID
+        when(todoRepository.save(any(TodoEntity.class))).thenAnswer(invocation -> {
+            TodoEntity entity = invocation.getArgument(0);
+            entity.setId(2L); // Simulate generated ID
+            return entity;
+        });
+
+        // When
+        List<TodoEntity> pendingOccurrences = repeatService.generateAllPendingOccurrences(userId);
+
+        // Then
+        assertThat(pendingOccurrences).hasSize(1);
+        assertThat(pendingOccurrences.get(0).getDueDate()).isAfter(LocalDate.of(2025, 1, 1));
+    }
+}

--- a/src/test/java/com/zametech/todoapp/application/service/TodoOwnershipServiceTest.java
+++ b/src/test/java/com/zametech/todoapp/application/service/TodoOwnershipServiceTest.java
@@ -36,12 +36,15 @@ class TodoOwnershipServiceTest {
 
     @Mock
     private UserContextService userContextService;
+    
+    @Mock
+    private RepeatService repeatService;
 
     private TodoService todoService;
 
     @BeforeEach
     void setUp() {
-        todoService = new TodoService(todoRepository, userContextService);
+        todoService = new TodoService(todoRepository, userContextService, repeatService);
     }
 
     @Test
@@ -52,6 +55,8 @@ class TodoOwnershipServiceTest {
                 "Test Description",
                 TodoPriority.HIGH,
                 LocalDate.now().plusDays(1),
+                null,
+                false,
                 null
         );
 
@@ -220,6 +225,8 @@ class TodoOwnershipServiceTest {
                 TodoStatus.DONE,
                 TodoPriority.HIGH,
                 LocalDate.now().plusDays(1),
+                null,
+                false,
                 null
         );
 
@@ -257,6 +264,8 @@ class TodoOwnershipServiceTest {
                 TodoStatus.DONE,
                 TodoPriority.HIGH,
                 LocalDate.now().plusDays(1),
+                null,
+                false,
                 null
         );
 

--- a/src/test/java/com/zametech/todoapp/application/service/TodoServiceParentChildTest.java
+++ b/src/test/java/com/zametech/todoapp/application/service/TodoServiceParentChildTest.java
@@ -34,6 +34,9 @@ class TodoServiceParentChildTest {
 
     @Mock
     private UserContextService userContextService;
+    
+    @Mock
+    private RepeatService repeatService;
 
     @InjectMocks
     private TodoService todoService;
@@ -72,7 +75,9 @@ class TodoServiceParentChildTest {
                 "Description",
                 TodoPriority.MEDIUM,
                 LocalDate.now().plusDays(7),
-                PARENT_TODO_ID
+                PARENT_TODO_ID,
+                false,
+                null
         );
 
         when(userContextService.getCurrentUserId()).thenReturn(USER_ID);
@@ -104,7 +109,9 @@ class TodoServiceParentChildTest {
                 "Description",
                 TodoPriority.MEDIUM,
                 LocalDate.now().plusDays(7),
-                999L
+                999L,
+                false,
+                null
         );
 
         when(userContextService.getCurrentUserId()).thenReturn(USER_ID);
@@ -124,7 +131,9 @@ class TodoServiceParentChildTest {
                 "Description",
                 TodoPriority.MEDIUM,
                 LocalDate.now().plusDays(7),
-                PARENT_TODO_ID
+                PARENT_TODO_ID,
+                false,
+                null
         );
 
         when(userContextService.getCurrentUserId()).thenReturn(USER_ID);
@@ -145,7 +154,9 @@ class TodoServiceParentChildTest {
                 TodoStatus.IN_PROGRESS,
                 TodoPriority.HIGH,
                 LocalDate.now().plusDays(7),
-                PARENT_TODO_ID
+                PARENT_TODO_ID,
+                false,
+                null
         );
 
         when(userContextService.getCurrentUserId()).thenReturn(USER_ID);
@@ -171,7 +182,9 @@ class TodoServiceParentChildTest {
                 TodoStatus.IN_PROGRESS,
                 TodoPriority.HIGH,
                 LocalDate.now().plusDays(7),
-                CHILD_TODO_ID  // Trying to set itself as parent
+                CHILD_TODO_ID,  // Trying to set itself as parent
+                false,
+                null
         );
 
         when(userContextService.getCurrentUserId()).thenReturn(USER_ID);

--- a/src/test/java/com/zametech/todoapp/application/service/TodoServiceRepeatTest.java
+++ b/src/test/java/com/zametech/todoapp/application/service/TodoServiceRepeatTest.java
@@ -1,0 +1,356 @@
+package com.zametech.todoapp.application.service;
+
+import com.zametech.todoapp.common.exception.TodoNotFoundException;
+import com.zametech.todoapp.domain.model.RepeatType;
+import com.zametech.todoapp.domain.model.TodoPriority;
+import com.zametech.todoapp.domain.model.TodoStatus;
+import com.zametech.todoapp.domain.repository.TodoRepository;
+import com.zametech.todoapp.infrastructure.persistence.entity.TodoEntity;
+import com.zametech.todoapp.presentation.dto.request.CreateTodoRequest;
+import com.zametech.todoapp.presentation.dto.request.RepeatConfigRequest;
+import com.zametech.todoapp.presentation.dto.request.UpdateTodoRequest;
+import com.zametech.todoapp.presentation.dto.response.TodoResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TodoServiceRepeatTest {
+
+    @Mock
+    private TodoRepository todoRepository;
+
+    @Mock
+    private UserContextService userContextService;
+
+    @Mock
+    private RepeatService repeatService;
+
+    @InjectMocks
+    private TodoService todoService;
+
+    @Test
+    void testCreateTodo_WithRepeatConfig() {
+        // Given
+        Long userId = 1L;
+        when(userContextService.getCurrentUserId()).thenReturn(userId);
+
+        RepeatConfigRequest repeatConfig = new RepeatConfigRequest(
+            RepeatType.DAILY,
+            1,
+            null,
+            null,
+            null
+        );
+
+        CreateTodoRequest request = new CreateTodoRequest(
+            "Daily Task",
+            "Daily task description",
+            TodoPriority.HIGH,
+            LocalDate.of(2025, 1, 1),
+            null,
+            true,
+            repeatConfig
+        );
+
+        TodoEntity savedTodo = new TodoEntity();
+        savedTodo.setId(1L);
+        savedTodo.setUserId(userId);
+        savedTodo.setTitle("Daily Task");
+        savedTodo.setIsRepeatable(true);
+        savedTodo.setRepeatType(RepeatType.DAILY);
+
+        when(todoRepository.save(any(TodoEntity.class))).thenReturn(savedTodo);
+
+        // When
+        TodoResponse response = todoService.createTodo(request);
+
+        // Then
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.title()).isEqualTo("Daily Task");
+        assertThat(response.isRepeatable()).isTrue();
+
+        verify(todoRepository).save(argThat(todo -> 
+            todo.getIsRepeatable() && 
+            todo.getRepeatType() == RepeatType.DAILY &&
+            todo.getRepeatInterval() == 1
+        ));
+    }
+
+    @Test
+    void testCreateTodo_WithoutRepeatConfig() {
+        // Given
+        Long userId = 1L;
+        when(userContextService.getCurrentUserId()).thenReturn(userId);
+
+        CreateTodoRequest request = new CreateTodoRequest(
+            "Normal Task",
+            "Normal task description",
+            TodoPriority.MEDIUM,
+            LocalDate.of(2025, 1, 1),
+            null,
+            false,
+            null
+        );
+
+        TodoEntity savedTodo = new TodoEntity();
+        savedTodo.setId(1L);
+        savedTodo.setUserId(userId);
+        savedTodo.setTitle("Normal Task");
+        savedTodo.setIsRepeatable(false);
+
+        when(todoRepository.save(any(TodoEntity.class))).thenReturn(savedTodo);
+
+        // When
+        TodoResponse response = todoService.createTodo(request);
+
+        // Then
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.title()).isEqualTo("Normal Task");
+        assertThat(response.isRepeatable()).isFalse();
+
+        verify(todoRepository).save(argThat(todo -> !todo.getIsRepeatable()));
+    }
+
+    @Test
+    void testUpdateTodo_EnableRepeat() {
+        // Given
+        Long todoId = 1L;
+        Long userId = 1L;
+        when(userContextService.getCurrentUserId()).thenReturn(userId);
+
+        TodoEntity existingTodo = new TodoEntity();
+        existingTodo.setId(todoId);
+        existingTodo.setUserId(userId);
+        existingTodo.setTitle("Task");
+        existingTodo.setIsRepeatable(false);
+
+        when(todoRepository.findById(todoId)).thenReturn(Optional.of(existingTodo));
+        when(todoRepository.save(any(TodoEntity.class))).thenReturn(existingTodo);
+
+        RepeatConfigRequest repeatConfig = new RepeatConfigRequest(
+            RepeatType.WEEKLY,
+            1,
+            List.of(1, 5), // Monday and Friday
+            null,
+            null
+        );
+
+        UpdateTodoRequest request = new UpdateTodoRequest(
+            "Updated Task",
+            "Updated description",
+            TodoStatus.TODO,
+            TodoPriority.HIGH,
+            LocalDate.of(2025, 1, 1),
+            null,
+            true,
+            repeatConfig
+        );
+
+        // When
+        TodoResponse response = todoService.updateTodo(todoId, request);
+
+        // Then
+        verify(todoRepository).save(argThat(todo -> 
+            todo.getIsRepeatable() && 
+            todo.getRepeatType() == RepeatType.WEEKLY &&
+            "1,5".equals(todo.getRepeatDaysOfWeek())
+        ));
+    }
+
+    @Test
+    void testUpdateTodo_DisableRepeat() {
+        // Given
+        Long todoId = 1L;
+        Long userId = 1L;
+        when(userContextService.getCurrentUserId()).thenReturn(userId);
+
+        TodoEntity existingTodo = new TodoEntity();
+        existingTodo.setId(todoId);
+        existingTodo.setUserId(userId);
+        existingTodo.setTitle("Task");
+        existingTodo.setIsRepeatable(true);
+        existingTodo.setRepeatType(RepeatType.DAILY);
+
+        when(todoRepository.findById(todoId)).thenReturn(Optional.of(existingTodo));
+        when(todoRepository.save(any(TodoEntity.class))).thenReturn(existingTodo);
+
+        UpdateTodoRequest request = new UpdateTodoRequest(
+            "Updated Task",
+            "Updated description",
+            TodoStatus.TODO,
+            TodoPriority.HIGH,
+            LocalDate.of(2025, 1, 1),
+            null,
+            false,
+            null
+        );
+
+        // When
+        TodoResponse response = todoService.updateTodo(todoId, request);
+
+        // Then
+        verify(todoRepository).save(argThat(todo -> 
+            !todo.getIsRepeatable() && 
+            todo.getRepeatType() == null
+        ));
+    }
+
+    @Test
+    void testUpdateTodo_CompletionGeneratesNext() {
+        // Given
+        Long todoId = 1L;
+        Long userId = 1L;
+        when(userContextService.getCurrentUserId()).thenReturn(userId);
+
+        TodoEntity existingTodo = new TodoEntity();
+        existingTodo.setId(todoId);
+        existingTodo.setUserId(userId);
+        existingTodo.setTitle("Repeatable Task");
+        existingTodo.setIsRepeatable(true);
+        existingTodo.setRepeatType(RepeatType.DAILY);
+        existingTodo.setOriginalTodoId(null); // 元のTODO
+
+        when(todoRepository.findById(todoId)).thenReturn(Optional.of(existingTodo));
+        when(todoRepository.save(any(TodoEntity.class))).thenReturn(existingTodo);
+
+        TodoEntity nextInstance = new TodoEntity();
+        when(repeatService.generateNextOccurrence(existingTodo)).thenReturn(nextInstance);
+
+        UpdateTodoRequest request = new UpdateTodoRequest(
+            "Repeatable Task",
+            "Description",
+            TodoStatus.DONE, // 完了にする
+            TodoPriority.MEDIUM,
+            LocalDate.of(2025, 1, 1),
+            null,
+            true,
+            new RepeatConfigRequest(RepeatType.DAILY, 1, null, null, null)
+        );
+
+        // When
+        todoService.updateTodo(todoId, request);
+
+        // Then
+        verify(repeatService).generateNextOccurrence(existingTodo);
+        verify(todoRepository, times(2)).save(any(TodoEntity.class)); // 元のTODOと次のインスタンス
+    }
+
+    @Test
+    void testGetRepeatableTodos() {
+        // Given
+        Long userId = 1L;
+        when(userContextService.getCurrentUserId()).thenReturn(userId);
+
+        TodoEntity repeatableTodo = new TodoEntity();
+        repeatableTodo.setId(1L);
+        repeatableTodo.setUserId(userId);
+        repeatableTodo.setTitle("Repeatable Task");
+        repeatableTodo.setIsRepeatable(true);
+
+        when(todoRepository.findByUserIdAndIsRepeatableTrue(userId)).thenReturn(List.of(repeatableTodo));
+
+        // When
+        List<TodoResponse> responses = todoService.getRepeatableTodos();
+
+        // Then
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).title()).isEqualTo("Repeatable Task");
+        assertThat(responses.get(0).isRepeatable()).isTrue();
+    }
+
+    @Test
+    void testGetRepeatInstances() {
+        // Given
+        Long originalTodoId = 1L;
+        Long userId = 1L;
+        when(userContextService.getCurrentUserId()).thenReturn(userId);
+
+        TodoEntity originalTodo = new TodoEntity();
+        originalTodo.setId(originalTodoId);
+        originalTodo.setUserId(userId);
+        originalTodo.setTitle("Original Task");
+
+        TodoEntity instance1 = new TodoEntity();
+        instance1.setId(2L);
+        instance1.setUserId(userId);
+        instance1.setTitle("Original Task");
+        instance1.setOriginalTodoId(originalTodoId);
+
+        when(todoRepository.findById(originalTodoId)).thenReturn(Optional.of(originalTodo));
+        when(todoRepository.findByOriginalTodoId(originalTodoId)).thenReturn(List.of(instance1));
+
+        // When
+        List<TodoResponse> responses = todoService.getRepeatInstances(originalTodoId);
+
+        // Then
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).originalTodoId()).isEqualTo(originalTodoId);
+    }
+
+    @Test
+    void testGetRepeatInstances_AccessDenied() {
+        // Given
+        Long originalTodoId = 1L;
+        Long userId = 1L;
+        Long otherUserId = 2L;
+        when(userContextService.getCurrentUserId()).thenReturn(userId);
+
+        TodoEntity originalTodo = new TodoEntity();
+        originalTodo.setId(originalTodoId);
+        originalTodo.setUserId(otherUserId); // 他のユーザーのTODO
+
+        when(todoRepository.findById(originalTodoId)).thenReturn(Optional.of(originalTodo));
+
+        // When & Then
+        assertThatThrownBy(() -> todoService.getRepeatInstances(originalTodoId))
+            .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void testGetRepeatInstances_NotFound() {
+        // Given
+        Long originalTodoId = 1L;
+        when(todoRepository.findById(originalTodoId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> todoService.getRepeatInstances(originalTodoId))
+            .isInstanceOf(TodoNotFoundException.class);
+    }
+
+    @Test
+    void testGeneratePendingRepeatInstances() {
+        // Given
+        Long userId = 1L;
+        when(userContextService.getCurrentUserId()).thenReturn(userId);
+
+        TodoEntity newInstance = new TodoEntity();
+        newInstance.setId(2L);
+        newInstance.setUserId(userId);
+        newInstance.setTitle("Generated Instance");
+
+        when(repeatService.generateAllPendingOccurrences(userId)).thenReturn(List.of(newInstance));
+        when(todoRepository.save(newInstance)).thenReturn(newInstance);
+
+        // When
+        List<TodoResponse> responses = todoService.generatePendingRepeatInstances();
+
+        // Then
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).title()).isEqualTo("Generated Instance");
+        verify(repeatService).generateAllPendingOccurrences(userId);
+        verify(todoRepository).save(newInstance);
+    }
+}

--- a/src/test/java/com/zametech/todoapp/integration/AnalyticsIntegrationTest.java
+++ b/src/test/java/com/zametech/todoapp/integration/AnalyticsIntegrationTest.java
@@ -109,6 +109,8 @@ class AnalyticsIntegrationTest {
                 "Test Description",
                 TodoPriority.MEDIUM,
                 LocalDate.now().plusDays(1),
+                null,
+                false,
                 null
         );
 

--- a/src/test/java/com/zametech/todoapp/integration/RepeatTodoIntegrationTest.java
+++ b/src/test/java/com/zametech/todoapp/integration/RepeatTodoIntegrationTest.java
@@ -1,0 +1,388 @@
+package com.zametech.todoapp.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zametech.todoapp.domain.model.RepeatType;
+import com.zametech.todoapp.domain.model.TodoPriority;
+import com.zametech.todoapp.domain.model.TodoStatus;
+import com.zametech.todoapp.infrastructure.persistence.entity.TodoEntity;
+import com.zametech.todoapp.infrastructure.persistence.entity.UserEntity;
+import com.zametech.todoapp.presentation.dto.request.CreateTodoRequest;
+import com.zametech.todoapp.presentation.dto.request.RepeatConfigRequest;
+import com.zametech.todoapp.presentation.dto.request.UpdateTodoRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class RepeatTodoIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private UserEntity testUser;
+
+    @BeforeEach
+    void setUp() {
+        // テストユーザー作成
+        testUser = new UserEntity();
+        testUser.setUsername("testuser");
+        testUser.setEmail("test@example.com");
+        testUser.setPassword("password");
+        entityManager.persist(testUser);
+        entityManager.flush();
+
+        // セキュリティコンテキストにユーザーを設定
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(
+                testUser.getUsername(),
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+            )
+        );
+    }
+
+    @Test
+    void testCreateDailyRepeatTodo() throws Exception {
+        // Given
+        RepeatConfigRequest repeatConfig = new RepeatConfigRequest(
+            RepeatType.DAILY,
+            1,
+            null,
+            null,
+            null
+        );
+
+        CreateTodoRequest request = new CreateTodoRequest(
+            "Daily Exercise",
+            "30 minutes workout",
+            TodoPriority.HIGH,
+            LocalDate.of(2025, 1, 1),
+            null,
+            true,
+            repeatConfig
+        );
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/todos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value("Daily Exercise"))
+                .andExpect(jsonPath("$.isRepeatable").value(true))
+                .andExpect(jsonPath("$.repeatConfig.repeatType").value("DAILY"))
+                .andExpect(jsonPath("$.repeatConfig.interval").value(1));
+
+        // データベースから検証
+        List<TodoEntity> todos = entityManager.createQuery(
+            "SELECT t FROM TodoEntity t WHERE t.userId = :userId AND t.isRepeatable = true", 
+            TodoEntity.class)
+            .setParameter("userId", testUser.getId())
+            .getResultList();
+
+        assert todos.size() == 1;
+        assert todos.get(0).getRepeatType() == RepeatType.DAILY;
+        assert todos.get(0).getRepeatInterval() == 1;
+    }
+
+    @Test
+    void testCreateWeeklyRepeatTodo() throws Exception {
+        // Given
+        RepeatConfigRequest repeatConfig = new RepeatConfigRequest(
+            RepeatType.WEEKLY,
+            1,
+            List.of(1, 3, 5), // Monday, Wednesday, Friday
+            null,
+            null
+        );
+
+        CreateTodoRequest request = new CreateTodoRequest(
+            "Gym Day",
+            "Strength training",
+            TodoPriority.MEDIUM,
+            LocalDate.of(2025, 1, 6), // Monday
+            null,
+            true,
+            repeatConfig
+        );
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/todos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.repeatConfig.repeatType").value("WEEKLY"))
+                .andExpect(jsonPath("$.repeatConfig.daysOfWeek", hasSize(3)))
+                .andExpect(jsonPath("$.repeatConfig.daysOfWeek", containsInAnyOrder(1, 3, 5)));
+
+        // データベースから検証
+        List<TodoEntity> todos = entityManager.createQuery(
+            "SELECT t FROM TodoEntity t WHERE t.userId = :userId AND t.repeatType = :repeatType", 
+            TodoEntity.class)
+            .setParameter("userId", testUser.getId())
+            .setParameter("repeatType", RepeatType.WEEKLY)
+            .getResultList();
+
+        assert todos.size() == 1;
+        assert "1,3,5".equals(todos.get(0).getRepeatDaysOfWeek());
+    }
+
+    @Test
+    void testCreateMonthlyRepeatTodo() throws Exception {
+        // Given
+        RepeatConfigRequest repeatConfig = new RepeatConfigRequest(
+            RepeatType.MONTHLY,
+            1,
+            null,
+            15, // 15th of each month
+            LocalDate.of(2025, 12, 31) // End date
+        );
+
+        CreateTodoRequest request = new CreateTodoRequest(
+            "Monthly Report",
+            "Submit monthly report",
+            TodoPriority.HIGH,
+            LocalDate.of(2025, 1, 15),
+            null,
+            true,
+            repeatConfig
+        );
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/todos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.repeatConfig.repeatType").value("MONTHLY"))
+                .andExpect(jsonPath("$.repeatConfig.dayOfMonth").value(15))
+                .andExpect(jsonPath("$.repeatConfig.endDate").value("2025-12-31"));
+    }
+
+    @Test
+    void testGetRepeatableTodos() throws Exception {
+        // Given - 繰り返し可能なTODOをいくつか作成
+        TodoEntity repeatableTodo1 = new TodoEntity(
+            testUser.getId(),
+            "Daily Task",
+            "Daily description",
+            TodoStatus.TODO,
+            TodoPriority.MEDIUM,
+            LocalDate.of(2025, 1, 1),
+            null,
+            true,
+            RepeatType.DAILY,
+            1,
+            null,
+            null,
+            null,
+            null
+        );
+
+        TodoEntity repeatableTodo2 = new TodoEntity(
+            testUser.getId(),
+            "Weekly Task",
+            "Weekly description",
+            TodoStatus.TODO,
+            TodoPriority.HIGH,
+            LocalDate.of(2025, 1, 6),
+            null,
+            true,
+            RepeatType.WEEKLY,
+            1,
+            "1,5",
+            null,
+            null,
+            null
+        );
+
+        // 非繰り返しTODO
+        TodoEntity normalTodo = new TodoEntity(
+            testUser.getId(),
+            "Normal Task",
+            "Normal description",
+            TodoStatus.TODO,
+            TodoPriority.LOW,
+            LocalDate.of(2025, 1, 10),
+            null
+        );
+
+        entityManager.persist(repeatableTodo1);
+        entityManager.persist(repeatableTodo2);
+        entityManager.persist(normalTodo);
+        entityManager.flush();
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/todos/repeatable"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[*].isRepeatable", everyItem(is(true))))
+                .andExpect(jsonPath("$[*].title", containsInAnyOrder("Daily Task", "Weekly Task")));
+    }
+
+    @Test
+    void testCompleteRepeatableTodoGeneratesNext() throws Exception {
+        // Given - 繰り返し可能なTODOを作成
+        RepeatConfigRequest repeatConfig = new RepeatConfigRequest(
+            RepeatType.DAILY,
+            1,
+            null,
+            null,
+            null
+        );
+
+        CreateTodoRequest createRequest = new CreateTodoRequest(
+            "Daily Exercise",
+            "30 minutes workout",
+            TodoPriority.HIGH,
+            LocalDate.of(2025, 1, 1),
+            null,
+            true,
+            repeatConfig
+        );
+
+        // TODO作成
+        String response = mockMvc.perform(post("/api/v1/todos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        Long todoId = objectMapper.readTree(response).get("id").asLong();
+
+        // TODO完了
+        UpdateTodoRequest updateRequest = new UpdateTodoRequest(
+            "Daily Exercise",
+            "30 minutes workout",
+            TodoStatus.DONE, // 完了にする
+            TodoPriority.HIGH,
+            LocalDate.of(2025, 1, 1),
+            null,
+            true,
+            repeatConfig
+        );
+
+        // When & Then
+        mockMvc.perform(put("/api/v1/todos/{id}", todoId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("DONE"));
+
+        // 新しいインスタンスが生成されたか確認
+        mockMvc.perform(get("/api/v1/todos/{originalTodoId}/instances", todoId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].dueDate").value("2025-01-02"))
+                .andExpect(jsonPath("$[0].status").value("TODO"))
+                .andExpect(jsonPath("$[0].isRepeatable").value(false))
+                .andExpect(jsonPath("$[0].originalTodoId").value(todoId));
+    }
+
+    @Test
+    void testGeneratePendingRepeatInstances() throws Exception {
+        // Given - 過去の期限のある繰り返しTODOを作成
+        TodoEntity overdueTodo = new TodoEntity(
+            testUser.getId(),
+            "Overdue Task",
+            "Should generate new instances",
+            TodoStatus.TODO,
+            TodoPriority.MEDIUM,
+            LocalDate.now().minusDays(3), // 3日前
+            null,
+            true,
+            RepeatType.DAILY,
+            1,
+            null,
+            null,
+            null,
+            null
+        );
+
+        entityManager.persist(overdueTodo);
+        entityManager.flush();
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/todos/repeat/generate"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$", hasSize(greaterThan(0))))
+                .andExpect(jsonPath("$[*].originalTodoId", everyItem(is(overdueTodo.getId().intValue()))))
+                .andExpect(jsonPath("$[*].isRepeatable", everyItem(is(false))));
+    }
+
+    @Test
+    void testUpdateTodoDisableRepeat() throws Exception {
+        // Given - 繰り返し可能なTODOを作成
+        TodoEntity repeatableTodo = new TodoEntity(
+            testUser.getId(),
+            "Repeatable Task",
+            "Initially repeatable",
+            TodoStatus.TODO,
+            TodoPriority.MEDIUM,
+            LocalDate.of(2025, 1, 1),
+            null,
+            true,
+            RepeatType.DAILY,
+            1,
+            null,
+            null,
+            null,
+            null
+        );
+
+        entityManager.persist(repeatableTodo);
+        entityManager.flush();
+
+        // 繰り返しを無効化
+        UpdateTodoRequest updateRequest = new UpdateTodoRequest(
+            "No Longer Repeatable Task",
+            "Disabled repeat",
+            TodoStatus.TODO,
+            TodoPriority.MEDIUM,
+            LocalDate.of(2025, 1, 1),
+            null,
+            false, // 繰り返し無効
+            null
+        );
+
+        // When & Then
+        mockMvc.perform(put("/api/v1/todos/{id}", repeatableTodo.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isRepeatable").value(false))
+                .andExpect(jsonPath("$.repeatConfig").value(nullValue()));
+
+        // データベースから検証
+        entityManager.clear();
+        TodoEntity updatedTodo = entityManager.find(TodoEntity.class, repeatableTodo.getId());
+        assert !updatedTodo.getIsRepeatable();
+        assert updatedTodo.getRepeatType() == null;
+    }
+}

--- a/src/test/java/com/zametech/todoapp/integration/TodoIntegrationTest.java
+++ b/src/test/java/com/zametech/todoapp/integration/TodoIntegrationTest.java
@@ -106,6 +106,8 @@ class TodoIntegrationTest {
             "Test Description",
             TodoPriority.HIGH,
             LocalDate.now().plusDays(7),
+            null,
+            false,
             null
         );
 
@@ -129,6 +131,8 @@ class TodoIntegrationTest {
             "Description",
             TodoPriority.MEDIUM,
             LocalDate.now().plusDays(1),
+            null,
+            false,
             null
         );
 
@@ -144,6 +148,8 @@ class TodoIntegrationTest {
             "Another Description",
             TodoPriority.LOW,
             LocalDate.now().plusDays(2),
+            null,
+            false,
             null
         );
 
@@ -177,6 +183,8 @@ class TodoIntegrationTest {
             "Private Description",
             TodoPriority.HIGH,
             LocalDate.now(),
+            null,
+            false,
             null
         );
 
@@ -203,6 +211,8 @@ class TodoIntegrationTest {
             TodoStatus.DONE,
             TodoPriority.LOW,
             LocalDate.now(),
+            null,
+            false,
             null
         );
 
@@ -226,6 +236,8 @@ class TodoIntegrationTest {
             "Original Description",
             TodoPriority.LOW,
             LocalDate.now().plusDays(3),
+            null,
+            false,
             null
         );
 
@@ -246,6 +258,8 @@ class TodoIntegrationTest {
             TodoStatus.IN_PROGRESS,
             TodoPriority.HIGH,
             LocalDate.now().plusDays(5),
+            null,
+            false,
             null
         );
 
@@ -269,6 +283,8 @@ class TodoIntegrationTest {
             "This will be deleted",
             TodoPriority.MEDIUM,
             LocalDate.now(),
+            null,
+            false,
             null
         );
 
@@ -302,6 +318,8 @@ class TodoIntegrationTest {
             "Description 1",
             TodoPriority.HIGH,
             LocalDate.now(),
+            null,
+            false,
             null
         );
 
@@ -310,6 +328,8 @@ class TodoIntegrationTest {
             "Description 2",
             TodoPriority.MEDIUM,
             LocalDate.now(),
+            null,
+            false,
             null
         );
 
@@ -338,6 +358,8 @@ class TodoIntegrationTest {
             TodoStatus.DONE,
             TodoPriority.MEDIUM,
             LocalDate.now(),
+            null,
+            false,
             null
         );
 

--- a/src/test/java/com/zametech/todoapp/presentation/controller/TodoControllerRepeatTest.java
+++ b/src/test/java/com/zametech/todoapp/presentation/controller/TodoControllerRepeatTest.java
@@ -1,0 +1,374 @@
+package com.zametech.todoapp.presentation.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zametech.todoapp.application.service.TodoService;
+import com.zametech.todoapp.domain.model.RepeatType;
+import com.zametech.todoapp.domain.model.TodoPriority;
+import com.zametech.todoapp.domain.model.TodoStatus;
+import com.zametech.todoapp.presentation.dto.request.CreateTodoRequest;
+import com.zametech.todoapp.presentation.dto.request.RepeatConfigRequest;
+import com.zametech.todoapp.presentation.dto.response.RepeatConfigResponse;
+import com.zametech.todoapp.presentation.dto.response.TodoResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(TodoController.class)
+@Import(TestSecurityConfig.class)
+class TodoControllerRepeatTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TodoService todoService;
+
+    @Test
+    @WithMockUser
+    void testCreateRepeatableTodo() throws Exception {
+        // Given
+        RepeatConfigRequest repeatConfig = new RepeatConfigRequest(
+            RepeatType.DAILY,
+            1,
+            null,
+            null,
+            null
+        );
+
+        CreateTodoRequest request = new CreateTodoRequest(
+            "Daily Task",
+            "Daily task description",
+            TodoPriority.HIGH,
+            LocalDate.of(2025, 1, 1),
+            null,
+            true,
+            repeatConfig
+        );
+
+        RepeatConfigResponse repeatConfigResponse = new RepeatConfigResponse(
+            RepeatType.DAILY,
+            1,
+            null,
+            null,
+            null
+        );
+
+        TodoResponse response = new TodoResponse(
+            1L,
+            "Daily Task",
+            "Daily task description",
+            TodoStatus.TODO,
+            TodoPriority.HIGH,
+            LocalDate.of(2025, 1, 1),
+            null,
+            true,
+            repeatConfigResponse,
+            null,
+            ZonedDateTime.now(),
+            ZonedDateTime.now()
+        );
+
+        when(todoService.createTodo(any(CreateTodoRequest.class))).thenReturn(response);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/todos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.title").value("Daily Task"))
+                .andExpect(jsonPath("$.isRepeatable").value(true))
+                .andExpect(jsonPath("$.repeatConfig.repeatType").value("DAILY"))
+                .andExpect(jsonPath("$.repeatConfig.interval").value(1));
+    }
+
+    @Test
+    @WithMockUser
+    void testCreateRepeatableTodo_Weekly() throws Exception {
+        // Given
+        RepeatConfigRequest repeatConfig = new RepeatConfigRequest(
+            RepeatType.WEEKLY,
+            1,
+            List.of(1, 5), // Monday and Friday
+            null,
+            null
+        );
+
+        CreateTodoRequest request = new CreateTodoRequest(
+            "Weekly Task",
+            "Weekly task description",
+            TodoPriority.MEDIUM,
+            LocalDate.of(2025, 1, 6), // Monday
+            null,
+            true,
+            repeatConfig
+        );
+
+        RepeatConfigResponse repeatConfigResponse = new RepeatConfigResponse(
+            RepeatType.WEEKLY,
+            1,
+            List.of(1, 5),
+            null,
+            null
+        );
+
+        TodoResponse response = new TodoResponse(
+            1L,
+            "Weekly Task",
+            "Weekly task description",
+            TodoStatus.TODO,
+            TodoPriority.MEDIUM,
+            LocalDate.of(2025, 1, 6),
+            null,
+            true,
+            repeatConfigResponse,
+            null,
+            ZonedDateTime.now(),
+            ZonedDateTime.now()
+        );
+
+        when(todoService.createTodo(any(CreateTodoRequest.class))).thenReturn(response);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/todos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.repeatConfig.repeatType").value("WEEKLY"))
+                .andExpect(jsonPath("$.repeatConfig.daysOfWeek[0]").value(1))
+                .andExpect(jsonPath("$.repeatConfig.daysOfWeek[1]").value(5));
+    }
+
+    @Test
+    @WithMockUser
+    void testGetRepeatableTodos() throws Exception {
+        // Given
+        RepeatConfigResponse repeatConfigResponse = new RepeatConfigResponse(
+            RepeatType.DAILY,
+            1,
+            null,
+            null,
+            null
+        );
+
+        TodoResponse todo1 = new TodoResponse(
+            1L,
+            "Daily Task 1",
+            "Description 1",
+            TodoStatus.TODO,
+            TodoPriority.HIGH,
+            LocalDate.of(2025, 1, 1),
+            null,
+            true,
+            repeatConfigResponse,
+            null,
+            ZonedDateTime.now(),
+            ZonedDateTime.now()
+        );
+
+        TodoResponse todo2 = new TodoResponse(
+            2L,
+            "Daily Task 2",
+            "Description 2",
+            TodoStatus.TODO,
+            TodoPriority.MEDIUM,
+            LocalDate.of(2025, 1, 2),
+            null,
+            true,
+            repeatConfigResponse,
+            null,
+            ZonedDateTime.now(),
+            ZonedDateTime.now()
+        );
+
+        when(todoService.getRepeatableTodos()).thenReturn(List.of(todo1, todo2));
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/todos/repeatable"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].id").value(1L))
+                .andExpect(jsonPath("$[0].isRepeatable").value(true))
+                .andExpect(jsonPath("$[1].id").value(2L))
+                .andExpect(jsonPath("$[1].isRepeatable").value(true));
+    }
+
+    @Test
+    @WithMockUser
+    void testGetRepeatInstances() throws Exception {
+        // Given
+        Long originalTodoId = 1L;
+
+        TodoResponse instance1 = new TodoResponse(
+            2L,
+            "Instance 1",
+            "Generated instance 1",
+            TodoStatus.TODO,
+            TodoPriority.MEDIUM,
+            LocalDate.of(2025, 1, 2),
+            null,
+            false,
+            null,
+            originalTodoId,
+            ZonedDateTime.now(),
+            ZonedDateTime.now()
+        );
+
+        TodoResponse instance2 = new TodoResponse(
+            3L,
+            "Instance 2",
+            "Generated instance 2",
+            TodoStatus.DONE,
+            TodoPriority.MEDIUM,
+            LocalDate.of(2025, 1, 3),
+            null,
+            false,
+            null,
+            originalTodoId,
+            ZonedDateTime.now(),
+            ZonedDateTime.now()
+        );
+
+        when(todoService.getRepeatInstances(originalTodoId)).thenReturn(List.of(instance1, instance2));
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/todos/{originalTodoId}/instances", originalTodoId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].id").value(2L))
+                .andExpect(jsonPath("$[0].originalTodoId").value(originalTodoId))
+                .andExpect(jsonPath("$[0].isRepeatable").value(false))
+                .andExpect(jsonPath("$[1].id").value(3L))
+                .andExpect(jsonPath("$[1].originalTodoId").value(originalTodoId))
+                .andExpect(jsonPath("$[1].status").value("DONE"));
+    }
+
+    @Test
+    @WithMockUser
+    void testGeneratePendingRepeatInstances() throws Exception {
+        // Given
+        TodoResponse generatedInstance = new TodoResponse(
+            5L,
+            "Generated Task",
+            "Auto-generated instance",
+            TodoStatus.TODO,
+            TodoPriority.MEDIUM,
+            LocalDate.of(2025, 1, 5),
+            null,
+            false,
+            null,
+            1L,
+            ZonedDateTime.now(),
+            ZonedDateTime.now()
+        );
+
+        when(todoService.generatePendingRepeatInstances()).thenReturn(List.of(generatedInstance));
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/todos/repeat/generate"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(5L))
+                .andExpect(jsonPath("$[0].title").value("Generated Task"))
+                .andExpect(jsonPath("$[0].originalTodoId").value(1L))
+                .andExpect(jsonPath("$[0].isRepeatable").value(false));
+    }
+
+    @Test
+    @WithMockUser
+    void testCreateRepeatableTodo_ValidationError() throws Exception {
+        // Given - 繰り返し設定が有効だが、repeatConfigがnull - バリデーションエラーはJSONマッピング時に発生
+
+        String invalidRequestJson = """
+            {
+                "title": "Invalid Task",
+                "description": "Task without repeat config",
+                "priority": "MEDIUM",
+                "dueDate": "2025-01-01",
+                "parentId": null,
+                "isRepeatable": true,
+                "repeatConfig": null
+            }
+            """;
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/todos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidRequestJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    void testCreateRepeatableTodo_MonthlyWithDayOfMonth() throws Exception {
+        // Given
+        RepeatConfigRequest repeatConfig = new RepeatConfigRequest(
+            RepeatType.MONTHLY,
+            1,
+            null,
+            15, // 毎月15日
+            LocalDate.of(2025, 12, 31) // 終了日
+        );
+
+        CreateTodoRequest request = new CreateTodoRequest(
+            "Monthly Task",
+            "Monthly on 15th",
+            TodoPriority.LOW,
+            LocalDate.of(2025, 1, 15),
+            null,
+            true,
+            repeatConfig
+        );
+
+        RepeatConfigResponse repeatConfigResponse = new RepeatConfigResponse(
+            RepeatType.MONTHLY,
+            1,
+            null,
+            15,
+            LocalDate.of(2025, 12, 31)
+        );
+
+        TodoResponse response = new TodoResponse(
+            1L,
+            "Monthly Task",
+            "Monthly on 15th",
+            TodoStatus.TODO,
+            TodoPriority.LOW,
+            LocalDate.of(2025, 1, 15),
+            null,
+            true,
+            repeatConfigResponse,
+            null,
+            ZonedDateTime.now(),
+            ZonedDateTime.now()
+        );
+
+        when(todoService.createTodo(any(CreateTodoRequest.class))).thenReturn(response);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/todos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.repeatConfig.repeatType").value("MONTHLY"))
+                .andExpect(jsonPath("$.repeatConfig.dayOfMonth").value(15))
+                .andExpect(jsonPath("$.repeatConfig.endDate").value("2025-12-31"));
+    }
+}


### PR DESCRIPTION
## Summary
- Implemented comprehensive repeatable TODO functionality for the personal-hub-backend
- Added support for daily, weekly, monthly, yearly, and one-time repeat patterns
- Created complete backend implementation with services, repositories, and API endpoints

## Features Added
- **Database Schema**: Added repeat fields to todos table via V8 migration
- **Domain Models**: Created RepeatType enum and RepeatConfig model
- **Service Layer**: Implemented RepeatService for handling repeat logic
- **API Endpoints**: Added endpoints for repeatable TODOs and instance management
- **Testing**: Created comprehensive unit, integration, and controller tests
- **Documentation**: Updated API.md and DATABASE.md with repeat functionality

## Technical Implementation
- Automatic generation of next occurrence when a repeatable TODO is completed
- Support for complex repeat patterns (weekly with specific days, monthly with date)
- Parent-child relationship tracking between original and generated TODOs
- Proper validation and error handling for repeat configurations

## Test Coverage
- RepeatService unit tests with date calculation logic
- TodoService repeat functionality tests
- Controller tests for all new endpoints
- Integration tests for complete workflow

## API Endpoints Added
- `GET /api/v1/todos/repeatable` - Get all repeatable TODOs
- `GET /api/v1/todos/{id}/instances` - Get instances of a repeatable TODO
- `POST /api/v1/todos/repeat/generate` - Generate pending repeat instances

🤖 Generated with [Claude Code](https://claude.ai/code)