### PR TITLE
feat: Implement GitHub OAuth authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@ GOOGLE_OIDC_CLIENT_ID=your_google_client_id_here
 GOOGLE_OIDC_CLIENT_SECRET=your_google_client_secret_here
 GOOGLE_OIDC_REDIRECT_URI=http://localhost:8080/api/v1/auth/oidc/google/callback
 
+# GitHub OAuth Configuration
+GITHUB_CLIENT_ID=your_github_client_id_here
+GITHUB_CLIENT_SECRET=your_github_client_secret_here
+GITHUB_REDIRECT_URI=http://localhost:8080/api/v1/auth/oidc/github/callback
+
 # Database Configuration
 DB_HOST=localhost
 DB_PORT=5432

--- a/docs/GITHUB_OAUTH_SETUP.md
+++ b/docs/GITHUB_OAUTH_SETUP.md
@@ -1,0 +1,137 @@
+# GitHub OAuth セットアップガイド
+
+## 概要
+Personal Hub バックエンドでGitHub OAuth認証を使用するための設定手順です。
+
+## 前提条件
+- GitHubアカウント
+- GitHub OAuthアプリケーション
+
+## セットアップ手順
+
+### 1. GitHub OAuthアプリケーション作成
+1. GitHubにログイン
+2. Settings → Developer settings → OAuth Appsに移動
+3. 「New OAuth App」または「Register a new application」をクリック
+4. 以下の情報を入力：
+   - **Application name**: Personal Hub Backend
+   - **Homepage URL**: http://localhost:8080
+   - **Application description**: Personal Hub OAuth authentication
+   - **Authorization callback URL**: http://localhost:8080/api/v1/auth/oidc/github/callback
+5. 「Register application」をクリック
+6. Client IDとClient Secretをメモ（Client Secretは「Generate a new client secret」で生成）
+
+### 2. 環境変数の設定
+プロジェクトルートの`.env`ファイルに以下を追加：
+
+```bash
+# GitHub OAuth Configuration
+GITHUB_CLIENT_ID=your_github_client_id_here
+GITHUB_CLIENT_SECRET=your_github_client_secret_here
+GITHUB_REDIRECT_URI=http://localhost:8080/api/v1/auth/oidc/github/callback
+```
+
+### 3. アプリケーション起動
+```bash
+# 環境変数を読み込んで起動
+source .env && mvn spring-boot:run
+```
+
+## 認証フロー
+
+### 1. 認証開始
+```
+GET /api/v1/auth/oidc/github/authorize
+```
+
+レスポンス:
+```json
+{
+  "authorizationUrl": "https://github.com/login/oauth/authorize?...",
+  "state": "random-state-value",
+  "provider": "github"
+}
+```
+
+### 2. GitHubログイン
+ユーザーをauthorizationUrlにリダイレクトし、GitHubアカウントでログイン
+
+### 3. コールバック処理
+GitHubからのリダイレクト後:
+```
+POST /api/v1/auth/oidc/github/callback
+Content-Type: application/json
+
+{
+  "code": "authorization-code-from-github",
+  "state": "state-from-step-1"
+}
+```
+
+レスポンス:
+```json
+{
+  "accessToken": "jwt-token",
+  "refreshToken": null,
+  "user": {
+    "id": "user-uuid",
+    "username": "github-username",
+    "email": "user@example.com",
+    "createdAt": "2023-01-01T00:00:00",
+    "updatedAt": "2023-01-01T00:00:00"
+  }
+}
+```
+
+## GitHub OAuthで取得される情報
+
+### ユーザー基本情報
+- GitHubユーザーID
+- ユーザー名（login）
+- 名前（フルネーム）
+- メールアドレス（プライマリ＋検証済み）
+- アバター画像URL
+
+### 追加プロフィール情報（保存のみ）
+- 会社名
+- ブログURL
+- 所在地
+- 自己紹介（bio）
+- パブリックリポジトリ数
+- フォロワー数
+- フォロー数
+
+## トラブルシューティング
+
+### エラー: redirect_uri_mismatch
+- GitHubアプリケーション設定の「Authorization callback URL」が正確に一致していることを確認
+- プロトコル（http/https）、ポート番号、パスが完全に一致している必要があります
+
+### エラー: bad_verification_code
+- 認可コードの有効期限切れ（10分）
+- 認可コードが既に使用済み
+- 不正な認可コード
+
+### エラー: incorrect_client_credentials
+- CLIENT_IDとCLIENT_SECRETが正しく設定されていることを確認
+- 環境変数が正しく読み込まれていることを確認
+
+## セキュリティ注意事項
+- `.env`ファイルは絶対にGitにコミットしないでください
+- 本番環境では必ずHTTPSを使用してください
+- CLIENT_SECRETは安全に管理し、フロントエンドには公開しないでください
+- GitHubアプリケーションの設定で適切なスコープのみを要求してください
+
+## 開発環境と本番環境の設定
+
+### 開発環境
+```
+Authorization callback URL: http://localhost:8080/api/v1/auth/oidc/github/callback
+```
+
+### 本番環境
+```
+Authorization callback URL: https://yourdomain.com/api/v1/auth/oidc/github/callback
+```
+
+複数の環境で使用する場合は、環境ごとに別のGitHub OAuthアプリケーションを作成することを推奨します。

--- a/src/main/java/com/zametech/todoapp/application/service/GitHubOAuthService.java
+++ b/src/main/java/com/zametech/todoapp/application/service/GitHubOAuthService.java
@@ -1,0 +1,383 @@
+package com.zametech.todoapp.application.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zametech.todoapp.domain.model.User;
+import com.zametech.todoapp.domain.model.UserSocialAccount;
+import com.zametech.todoapp.domain.repository.UserRepository;
+import com.zametech.todoapp.domain.repository.UserSocialAccountRepository;
+import com.zametech.todoapp.presentation.dto.request.OidcCallbackRequest;
+import com.zametech.todoapp.presentation.dto.response.AuthenticationResponse;
+import com.zametech.todoapp.presentation.dto.response.UserResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GitHubOAuthService {
+
+    private static final String GITHUB_AUTH_URL = "https://github.com/login/oauth/authorize";
+    private static final String GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
+    private static final String GITHUB_USER_URL = "https://api.github.com/user";
+    private static final String GITHUB_USER_EMAILS_URL = "https://api.github.com/user/emails";
+    private static final String PROVIDER_NAME = "github";
+
+    @Value("${github.client.id}")
+    private String clientId;
+
+    @Value("${github.client.secret}")
+    private String clientSecret;
+
+    @Value("${github.redirect.uri}")
+    private String redirectUri;
+
+    private final UserRepository userRepository;
+    private final UserSocialAccountRepository socialAccountRepository;
+    private final OidcTokenService tokenService;
+    private final SecurityEventService securityEventService;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * GitHub認証URLを生成
+     */
+    public String generateAuthorizationUrl(String state) {
+        return UriComponentsBuilder.fromHttpUrl(GITHUB_AUTH_URL)
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("scope", "read:user user:email")
+                .queryParam("state", state)
+                .build()
+                .toUriString();
+    }
+
+    /**
+     * GitHub OAuthコールバック処理
+     */
+    @Transactional
+    public AuthenticationResponse handleCallback(OidcCallbackRequest request, String ipAddress, String userAgent) {
+        try {
+            // 1. 認可コードをアクセストークンに交換
+            String accessToken = exchangeCodeForToken(request.code());
+            
+            // 2. ユーザー情報を取得
+            Map<String, Object> userInfo = fetchUserInfo(accessToken);
+            Map<String, Object> primaryEmail = fetchPrimaryEmail(accessToken);
+            
+            // 3. ユーザーアカウントを作成または更新
+            User user = findOrCreateUser(userInfo, primaryEmail);
+            
+            // 4. ソーシャルアカウント情報を保存
+            saveSocialAccount(user, userInfo, primaryEmail, accessToken);
+            
+            // 5. JWTトークンを生成
+            String jwtToken = tokenService.generateToken(user);
+            
+            // 6. セキュリティイベントを記録
+            securityEventService.recordLoginSuccess(user, PROVIDER_NAME, ipAddress, userAgent, null);
+            
+            log.info("GitHub OAuth authentication successful for user: {}", user.getEmail());
+            
+            UserResponse userResponse = new UserResponse(
+                    user.getId(),
+                    user.getUsername(),
+                    user.getEmail(),
+                    user.getCreatedAt(),
+                    user.getUpdatedAt()
+            );
+            
+            return new AuthenticationResponse(
+                    jwtToken,
+                    null, // No refresh token for OAuth login
+                    userResponse
+            );
+            
+        } catch (Exception e) {
+            log.error("GitHub OAuth authentication failed", e);
+            securityEventService.recordLoginFailure(null, PROVIDER_NAME, ipAddress, userAgent, 
+                    "GITHUB_AUTH_FAILED", e.getMessage(), null);
+            throw new RuntimeException("GitHub authentication failed", e);
+        }
+    }
+
+    /**
+     * 認可コードをアクセストークンに交換
+     */
+    private String exchangeCodeForToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Accept", "application/json");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("code", code);
+        params.add("redirect_uri", redirectUri);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<JsonNode> response = restTemplate.exchange(
+                    GITHUB_TOKEN_URL,
+                    HttpMethod.POST,
+                    request,
+                    JsonNode.class
+            );
+
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                JsonNode body = response.getBody();
+                if (body.has("access_token")) {
+                    return body.get("access_token").asText();
+                } else if (body.has("error")) {
+                    String error = body.get("error").asText();
+                    String errorDescription = body.has("error_description") ? 
+                            body.get("error_description").asText() : "Unknown error";
+                    throw new RuntimeException("GitHub token exchange failed: " + error + " - " + errorDescription);
+                }
+            }
+            
+            throw new RuntimeException("Failed to exchange code for token");
+            
+        } catch (Exception e) {
+            log.error("Error exchanging code for token", e);
+            throw new RuntimeException("Failed to exchange authorization code", e);
+        }
+    }
+
+    /**
+     * GitHubユーザー情報を取得
+     */
+    private Map<String, Object> fetchUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.set("Accept", "application/vnd.github.v3+json");
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    GITHUB_USER_URL,
+                    HttpMethod.GET,
+                    request,
+                    Map.class
+            );
+
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                return response.getBody();
+            }
+            
+            throw new RuntimeException("Failed to fetch user info");
+            
+        } catch (Exception e) {
+            log.error("Error fetching GitHub user info", e);
+            throw new RuntimeException("Failed to fetch user information", e);
+        }
+    }
+
+    /**
+     * GitHubプライマリメールアドレスを取得
+     */
+    private Map<String, Object> fetchPrimaryEmail(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.set("Accept", "application/vnd.github.v3+json");
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<JsonNode> response = restTemplate.exchange(
+                    GITHUB_USER_EMAILS_URL,
+                    HttpMethod.GET,
+                    request,
+                    JsonNode.class
+            );
+
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                JsonNode emails = response.getBody();
+                for (JsonNode email : emails) {
+                    if (email.get("primary").asBoolean()) {
+                        Map<String, Object> emailInfo = new HashMap<>();
+                        emailInfo.put("email", email.get("email").asText());
+                        emailInfo.put("verified", email.get("verified").asBoolean());
+                        return emailInfo;
+                    }
+                }
+            }
+            
+            throw new RuntimeException("No primary email found");
+            
+        } catch (Exception e) {
+            log.error("Error fetching GitHub user emails", e);
+            throw new RuntimeException("Failed to fetch user email", e);
+        }
+    }
+
+    /**
+     * ユーザーを検索または作成
+     */
+    private User findOrCreateUser(Map<String, Object> userInfo, Map<String, Object> emailInfo) {
+        String githubId = String.valueOf(userInfo.get("id"));
+        String email = (String) emailInfo.get("email");
+        boolean emailVerified = (boolean) emailInfo.get("verified");
+        
+        // まずソーシャルアカウントで検索
+        Optional<UserSocialAccount> socialAccount = socialAccountRepository
+                .findByProviderAndProviderUserId(PROVIDER_NAME, githubId);
+        
+        if (socialAccount.isPresent()) {
+            return socialAccount.get().getUser();
+        }
+        
+        // メールアドレスで既存ユーザーを検索
+        Optional<User> existingUser = userRepository.findByEmail(email);
+        
+        if (existingUser.isPresent()) {
+            // 既存ユーザーにGitHubアカウントをリンク
+            User user = existingUser.get();
+            updateUserFromGitHub(user, userInfo, emailInfo);
+            return userRepository.save(user);
+        }
+        
+        // 新規ユーザーを作成
+        return createNewUser(userInfo, emailInfo);
+    }
+
+    /**
+     * 新規ユーザーを作成
+     */
+    private User createNewUser(Map<String, Object> userInfo, Map<String, Object> emailInfo) {
+        User user = new User();
+        user.setEmail((String) emailInfo.get("email"));
+        user.setEmailVerified((boolean) emailInfo.get("verified"));
+        user.setUsername(generateUsername(userInfo));
+        
+        // GitHubプロフィール情報を設定
+        if (userInfo.get("name") != null) {
+            String fullName = (String) userInfo.get("name");
+            String[] nameParts = fullName.split(" ", 2);
+            if (nameParts.length > 0) {
+                user.setGivenName(nameParts[0]);
+            }
+            if (nameParts.length > 1) {
+                user.setFamilyName(nameParts[1]);
+            }
+        }
+        
+        if (userInfo.get("avatar_url") != null) {
+            user.setProfilePictureUrl((String) userInfo.get("avatar_url"));
+        }
+        
+        // GitHubユーザーはパスワードなし
+        user.setPassword(null);
+        
+        user.setCreatedAt(LocalDateTime.now());
+        user.setUpdatedAt(LocalDateTime.now());
+        
+        return userRepository.save(user);
+    }
+
+    /**
+     * 既存ユーザー情報をGitHubから更新
+     */
+    private void updateUserFromGitHub(User user, Map<String, Object> userInfo, Map<String, Object> emailInfo) {
+        if (!user.isEmailVerified() && (boolean) emailInfo.get("verified")) {
+            user.setEmailVerified(true);
+        }
+        
+        if (user.getGivenName() == null && userInfo.get("name") != null) {
+            String fullName = (String) userInfo.get("name");
+            String[] nameParts = fullName.split(" ", 2);
+            if (nameParts.length > 0) {
+                user.setGivenName(nameParts[0]);
+            }
+            if (nameParts.length > 1) {
+                user.setFamilyName(nameParts[1]);
+            }
+        }
+        
+        if (user.getProfilePictureUrl() == null && userInfo.get("avatar_url") != null) {
+            user.setProfilePictureUrl((String) userInfo.get("avatar_url"));
+        }
+        
+        user.setUpdatedAt(LocalDateTime.now());
+    }
+
+    /**
+     * ソーシャルアカウント情報を保存
+     */
+    private void saveSocialAccount(User user, Map<String, Object> userInfo, Map<String, Object> emailInfo, String accessToken) {
+        String githubId = String.valueOf(userInfo.get("id"));
+        Optional<UserSocialAccount> existing = socialAccountRepository
+                .findByUserIdAndProvider(user.getId(), PROVIDER_NAME);
+        
+        UserSocialAccount socialAccount;
+        if (existing.isPresent()) {
+            socialAccount = existing.get();
+            socialAccount.setUpdatedAt(LocalDateTime.now());
+        } else {
+            socialAccount = UserSocialAccount.builder()
+                    .user(user)
+                    .provider(PROVIDER_NAME)
+                    .providerUserId(githubId)
+                    .email((String) emailInfo.get("email"))
+                    .emailVerified((boolean) emailInfo.get("verified"))
+                    .name((String) userInfo.get("name"))
+                    .picture((String) userInfo.get("avatar_url"))
+                    .createdAt(LocalDateTime.now())
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+        }
+        
+        // プロファイルデータを保存
+        Map<String, Object> profileData = new HashMap<>();
+        profileData.put("login", userInfo.get("login"));
+        profileData.put("id", userInfo.get("id"));
+        profileData.put("node_id", userInfo.get("node_id"));
+        profileData.put("avatar_url", userInfo.get("avatar_url"));
+        profileData.put("html_url", userInfo.get("html_url"));
+        profileData.put("name", userInfo.get("name"));
+        profileData.put("company", userInfo.get("company"));
+        profileData.put("blog", userInfo.get("blog"));
+        profileData.put("location", userInfo.get("location"));
+        profileData.put("bio", userInfo.get("bio"));
+        profileData.put("public_repos", userInfo.get("public_repos"));
+        profileData.put("followers", userInfo.get("followers"));
+        profileData.put("following", userInfo.get("following"));
+        socialAccount.setProfileData(profileData);
+        
+        // トークンを暗号化して保存（TODO: 実装）
+        // socialAccount.setAccessTokenEncrypted(encryptToken(accessToken));
+        
+        socialAccountRepository.save(socialAccount);
+    }
+
+    /**
+     * ユーザー名を生成
+     */
+    private String generateUsername(Map<String, Object> userInfo) {
+        String login = (String) userInfo.get("login");
+        String username = login;
+        int counter = 1;
+        
+        while (userRepository.existsByUsername(username)) {
+            username = login + counter++;
+        }
+        
+        return username;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -94,12 +94,11 @@ google:
       url: https://accounts.google.com/.well-known/openid-configuration
 
 github:
-  oauth:
-    client:
-      id: ${GITHUB_CLIENT_ID:}
-      secret: ${GITHUB_CLIENT_SECRET:}
-    redirect:
-      uri: ${GITHUB_REDIRECT_URI:http://localhost:8080/auth/github/callback}
+  client:
+    id: ${GITHUB_CLIENT_ID:}
+    secret: ${GITHUB_CLIENT_SECRET:}
+  redirect:
+    uri: ${GITHUB_REDIRECT_URI:http://localhost:8080/api/v1/auth/oidc/github/callback}
 
 management:
   endpoints:

--- a/src/test/java/com/zametech/todoapp/application/service/GitHubOAuthServiceTest.java
+++ b/src/test/java/com/zametech/todoapp/application/service/GitHubOAuthServiceTest.java
@@ -1,0 +1,260 @@
+package com.zametech.todoapp.application.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.zametech.todoapp.domain.model.User;
+import com.zametech.todoapp.domain.model.UserSocialAccount;
+import com.zametech.todoapp.domain.repository.UserRepository;
+import com.zametech.todoapp.domain.repository.UserSocialAccountRepository;
+import com.zametech.todoapp.presentation.dto.request.OidcCallbackRequest;
+import com.zametech.todoapp.presentation.dto.response.AuthenticationResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GitHubOAuthServiceTest {
+    
+    @Mock
+    private UserRepository userRepository;
+    
+    @Mock
+    private UserSocialAccountRepository socialAccountRepository;
+    
+    @Mock
+    private OidcTokenService tokenService;
+    
+    @Mock
+    private SecurityEventService securityEventService;
+    
+    @Mock
+    private RestTemplate restTemplate;
+    
+    @Mock
+    private ObjectMapper objectMapper;
+    
+    @InjectMocks
+    private GitHubOAuthService gitHubOAuthService;
+    
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(gitHubOAuthService, "clientId", "test-client-id");
+        ReflectionTestUtils.setField(gitHubOAuthService, "clientSecret", "test-client-secret");
+        ReflectionTestUtils.setField(gitHubOAuthService, "redirectUri", "http://localhost:8080/callback");
+    }
+    
+    @Test
+    void generateAuthorizationUrl_shouldReturnCorrectUrl() {
+        // Act
+        String authUrl = gitHubOAuthService.generateAuthorizationUrl("test-state");
+        
+        // Assert
+        assertThat(authUrl).contains("https://github.com/login/oauth/authorize");
+        assertThat(authUrl).contains("client_id=test-client-id");
+        assertThat(authUrl).contains("redirect_uri=http://localhost:8080/callback");
+        assertThat(authUrl).contains("scope=read:user user:email");
+        assertThat(authUrl).contains("state=test-state");
+    }
+    
+    @Test
+    void handleCallback_withNewUser_shouldCreateUserAndReturnToken() throws Exception {
+        // Arrange
+        String authCode = "test-auth-code";
+        String accessToken = "test-access-token";
+        String jwtToken = "test-jwt-token";
+        
+        OidcCallbackRequest request = new OidcCallbackRequest(authCode, "test-state", null, null);
+        
+        // Mock token exchange
+        ObjectMapper realMapper = new ObjectMapper();
+        JsonNode tokenResponse = realMapper.createObjectNode()
+                .put("access_token", accessToken)
+                .put("token_type", "bearer");
+        
+        when(restTemplate.exchange(
+                contains("github.com/login/oauth/access_token"),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        )).thenReturn(ResponseEntity.ok(tokenResponse));
+        
+        // Mock user info
+        Map<String, Object> userInfo = new HashMap<>();
+        userInfo.put("id", 12345);
+        userInfo.put("login", "testuser");
+        userInfo.put("name", "Test User");
+        userInfo.put("avatar_url", "https://github.com/avatar.jpg");
+        
+        when(restTemplate.exchange(
+                contains("api.github.com/user"),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(Map.class)
+        )).thenReturn(ResponseEntity.ok(userInfo));
+        
+        // Mock email info
+        ArrayNode emailNode = realMapper.createArrayNode();
+        ObjectNode emailObj = realMapper.createObjectNode();
+        emailObj.put("email", "test@example.com");
+        emailObj.put("primary", true);
+        emailObj.put("verified", true);
+        emailNode.add(emailObj);
+        
+        when(restTemplate.exchange(
+                contains("api.github.com/user/emails"),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        )).thenReturn(ResponseEntity.ok(emailNode));
+        
+        // Mock repository calls
+        when(socialAccountRepository.findByProviderAndProviderUserId("github", "12345"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmail("test@example.com"))
+                .thenReturn(Optional.empty());
+        when(userRepository.existsByUsername("testuser"))
+                .thenReturn(false);
+        
+        User savedUser = new User();
+        savedUser.setId(UUID.randomUUID());
+        savedUser.setEmail("test@example.com");
+        savedUser.setUsername("testuser");
+        savedUser.setCreatedAt(LocalDateTime.now());
+        savedUser.setUpdatedAt(LocalDateTime.now());
+        
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+        when(tokenService.generateToken(any(User.class))).thenReturn(jwtToken);
+        
+        // Act
+        AuthenticationResponse response = gitHubOAuthService.handleCallback(request, "127.0.0.1", "Test Browser");
+        
+        // Assert
+        assertThat(response).isNotNull();
+        assertThat(response.getAccessToken()).isEqualTo(jwtToken);
+        assertThat(response.getUser()).isNotNull();
+        assertThat(response.getUser().email()).isEqualTo("test@example.com");
+        assertThat(response.getUser().username()).isEqualTo("testuser");
+    }
+    
+    @Test
+    void handleCallback_withExistingUser_shouldReturnToken() throws Exception {
+        // Arrange
+        String authCode = "test-auth-code";
+        String accessToken = "test-access-token";
+        String jwtToken = "test-jwt-token";
+        
+        OidcCallbackRequest request = new OidcCallbackRequest(authCode, "test-state", null, null);
+        
+        // Mock token exchange
+        ObjectMapper realMapper = new ObjectMapper();
+        JsonNode tokenResponse = realMapper.createObjectNode()
+                .put("access_token", accessToken)
+                .put("token_type", "bearer");
+        
+        when(restTemplate.exchange(
+                contains("github.com/login/oauth/access_token"),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        )).thenReturn(ResponseEntity.ok(tokenResponse));
+        
+        // Mock user info
+        Map<String, Object> userInfo = new HashMap<>();
+        userInfo.put("id", 12345);
+        userInfo.put("login", "testuser");
+        userInfo.put("name", "Test User");
+        userInfo.put("avatar_url", "https://github.com/avatar.jpg");
+        
+        when(restTemplate.exchange(
+                contains("api.github.com/user"),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(Map.class)
+        )).thenReturn(ResponseEntity.ok(userInfo));
+        
+        // Mock email info
+        ArrayNode emailNode = realMapper.createArrayNode();
+        ObjectNode emailObj = realMapper.createObjectNode();
+        emailObj.put("email", "test@example.com");
+        emailObj.put("primary", true);
+        emailObj.put("verified", true);
+        emailNode.add(emailObj);
+        
+        when(restTemplate.exchange(
+                contains("api.github.com/user/emails"),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        )).thenReturn(ResponseEntity.ok(emailNode));
+        
+        // Mock existing user with social account
+        User existingUser = new User();
+        existingUser.setId(UUID.randomUUID());
+        existingUser.setEmail("test@example.com");
+        existingUser.setUsername("testuser");
+        existingUser.setCreatedAt(LocalDateTime.now());
+        existingUser.setUpdatedAt(LocalDateTime.now());
+        
+        UserSocialAccount socialAccount = UserSocialAccount.builder()
+                .user(existingUser)
+                .provider("github")
+                .providerUserId("12345")
+                .build();
+        
+        when(socialAccountRepository.findByProviderAndProviderUserId("github", "12345"))
+                .thenReturn(Optional.of(socialAccount));
+        when(tokenService.generateToken(existingUser)).thenReturn(jwtToken);
+        
+        // Act
+        AuthenticationResponse response = gitHubOAuthService.handleCallback(request, "127.0.0.1", "Test Browser");
+        
+        // Assert
+        assertThat(response).isNotNull();
+        assertThat(response.getAccessToken()).isEqualTo(jwtToken);
+        assertThat(response.getUser()).isNotNull();
+        assertThat(response.getUser().email()).isEqualTo("test@example.com");
+    }
+    
+    @Test
+    void handleCallback_withInvalidCode_shouldThrowException() {
+        // Arrange
+        OidcCallbackRequest request = new OidcCallbackRequest("invalid-code", "test-state", null, null);
+        
+        ObjectMapper realMapper = new ObjectMapper();
+        JsonNode errorResponse = realMapper.createObjectNode()
+                .put("error", "bad_verification_code")
+                .put("error_description", "The code is incorrect");
+        
+        when(restTemplate.exchange(
+                contains("github.com/login/oauth/access_token"),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        )).thenReturn(ResponseEntity.ok(errorResponse));
+        
+        // Act & Assert
+        assertThatThrownBy(() -> 
+                gitHubOAuthService.handleCallback(request, "127.0.0.1", "Test Browser"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("GitHub authentication failed");
+    }
+}


### PR DESCRIPTION
## Summary
- Implemented GitHub OAuth authentication (Issue #23)
- Added endpoints for GitHub OAuth flow
- Created social account linking functionality for GitHub users

## Changes
- GitHubOAuthService for handling GitHub OAuth flow
- Updated OidcController with /api/v1/auth/oidc/github/authorize and callback endpoints
- Comprehensive tests for GitHub OAuth service
- Configuration for GitHub OAuth client credentials
- Documentation for GitHub OAuth setup

## Features
- GitHub authorization URL generation with appropriate scopes
- OAuth code exchange for access token
- User profile and primary email fetching from GitHub API
- Social account linking for existing users
- New user creation from GitHub profile with avatar and name

## Test Plan
- [x] Unit tests for GitHubOAuthService (all passing)
- [ ] Manual testing with GitHub account
- [ ] Verify social account linking with existing users
- [ ] Test new user registration via GitHub

## Configuration Required
Set the following environment variables:
- GITHUB_CLIENT_ID
- GITHUB_CLIENT_SECRET
- GITHUB_REDIRECT_URI (default: http://localhost:8080/api/v1/auth/oidc/github/callback)

## Documentation
Added comprehensive setup guide at `docs/GITHUB_OAUTH_SETUP.md` including:
- GitHub OAuth App creation steps
- Environment variable configuration
- Authentication flow documentation
- Troubleshooting guide

🤖 Generated with [Claude Code](https://claude.ai/code)