### PR TITLE
Fix all test failures for first release

### DIFF
--- a/src/main/java/com/zametech/todoapp/infrastructure/security/JwtService.java
+++ b/src/main/java/com/zametech/todoapp/infrastructure/security/JwtService.java
@@ -5,8 +5,12 @@ import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jwt.SignedJWT;
 import com.zametech.todoapp.application.service.JwksService;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
@@ -159,8 +163,12 @@ public class JwtService {
                     .build()
                     .parseSignedClaims(token)
                     .getPayload();
+        } catch (ExpiredJwtException | MalformedJwtException | SignatureException | UnsupportedJwtException e) {
+            // Propagate specific JWT exceptions as-is
+            log.error("JWT token validation failed: {}", e.getMessage());
+            throw e;
         } catch (Exception e) {
-            log.error("Failed to parse JWT token with both RS256 and HS256", e);
+            log.error("Unexpected error parsing JWT token", e);
             throw new io.jsonwebtoken.JwtException("Invalid JWT token", e);
         }
     }

--- a/src/test/java/com/zametech/todoapp/presentation/controller/AnalyticsControllerIntegrationTest.java
+++ b/src/test/java/com/zametech/todoapp/presentation/controller/AnalyticsControllerIntegrationTest.java
@@ -26,10 +26,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureWebMvc
-@TestPropertySource(properties = {
-    "spring.datasource.url=jdbc:h2:mem:testdb",
-    "spring.jpa.hibernate.ddl-auto=create-drop"
-})
 class AnalyticsControllerIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/zametech/todoapp/presentation/controller/AuthenticationControllerTest.java
+++ b/src/test/java/com/zametech/todoapp/presentation/controller/AuthenticationControllerTest.java
@@ -1,6 +1,7 @@
 package com.zametech.todoapp.presentation.controller;
 
 import com.zametech.todoapp.application.service.AuthenticationService;
+import com.zametech.todoapp.application.service.PasswordResetService;
 import com.zametech.todoapp.application.service.UserContextService;
 import com.zametech.todoapp.domain.model.User;
 import com.zametech.todoapp.presentation.dto.request.LoginRequest;
@@ -44,6 +45,9 @@ class AuthenticationControllerTest {
     
     @MockBean
     private UserContextService userContextService;
+    
+    @MockBean
+    private PasswordResetService passwordResetService;
 
     @Test
     void shouldRegisterUserSuccessfully() throws Exception {

--- a/src/test/java/com/zametech/todoapp/presentation/controller/CalendarSyncControllerTest.java
+++ b/src/test/java/com/zametech/todoapp/presentation/controller/CalendarSyncControllerTest.java
@@ -63,7 +63,7 @@ class CalendarSyncControllerTest {
         when(calendarSyncService.getSyncStatus()).thenReturn(response);
 
         // When & Then
-        mockMvc.perform(get("/api/v1/calendar/sync/status"))
+        mockMvc.perform(get("/api/v1/calendar/sync/status/detailed"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isConnected").value(true))
                 .andExpect(jsonPath("$.syncStatus").value("SUCCESS"))
@@ -82,7 +82,7 @@ class CalendarSyncControllerTest {
         when(calendarSyncSettingsRepository.findByUserId(userId)).thenReturn(List.of());
         
         // When & Then
-        mockMvc.perform(get("/api/v1/calendar/sync/settings"))
+        mockMvc.perform(get("/api/v1/calendar/sync/settings/list"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray())
                 .andExpect(jsonPath("$").isEmpty());

--- a/src/test/java/com/zametech/todoapp/presentation/controller/OidcControllerTest.java
+++ b/src/test/java/com/zametech/todoapp/presentation/controller/OidcControllerTest.java
@@ -1,6 +1,8 @@
 package com.zametech.todoapp.presentation.controller;
 
+import com.zametech.todoapp.application.service.GitHubOAuthService;
 import com.zametech.todoapp.application.service.GoogleOidcService;
+import com.zametech.todoapp.application.service.OAuthStateService;
 import com.zametech.todoapp.presentation.dto.request.OidcCallbackRequest;
 import com.zametech.todoapp.presentation.dto.response.AuthenticationResponse;
 import com.zametech.todoapp.presentation.dto.response.UserResponse;
@@ -26,13 +28,28 @@ class OidcControllerTest {
     @Mock
     private GoogleOidcService googleOidcService;
     
+    @Mock
+    private GitHubOAuthService gitHubOAuthService;
+    
+    @Mock
+    private OAuthStateService oAuthStateService;
+    
     @InjectMocks
     private OidcController oidcController;
     
     @Test
     void testInitiateGoogleAuth() {
+        // Arrange
+        String state = "test-state-123";
+        String authUrl = "https://accounts.google.com/oauth2/v2/auth?client_id=test&state=test-state-123";
+        
+        when(oAuthStateService.generateState("google")).thenReturn(state);
+        when(googleOidcService.generateAuthorizationUrl(anyString(), anyString())).thenReturn(authUrl);
+        
+        // Act
         ResponseEntity<?> response = oidcController.initiateGoogleAuth();
         
+        // Assert
         assertThat(response.getStatusCodeValue()).isEqualTo(200);
         assertThat(response.getBody()).isNotNull();
     }
@@ -60,6 +77,7 @@ class OidcControllerTest {
                 userResponse
         );
         
+        when(oAuthStateService.validateStateAndGetProvider("test-state")).thenReturn("google");
         when(googleOidcService.handleCallback(any(OidcCallbackRequest.class), anyString(), anyString()))
                 .thenReturn(authResponse);
         


### PR DESCRIPTION
## Summary
- Fixed all 12+ test failures that were blocking the first release
- All 175 tests now pass successfully

## Changes Made
1. **JwtServiceTest** - Fixed 3 failing tests by propagating specific JWT exceptions (ExpiredJwtException, MalformedJwtException, SignatureException) instead of wrapping them in a generic JwtException
2. **AuthenticationControllerTest** - Fixed 5 failing tests by adding the missing PasswordResetService mock
3. **CalendarSyncControllerTest** - Fixed 2 failing tests by correcting endpoint URLs to match actual controller mappings (/status/detailed and /settings/list)
4. **OidcControllerTest** - Fixed 2 failing tests by adding missing service mocks (GitHubOAuthService and OAuthStateService)
5. **AnalyticsControllerIntegrationTest** - Fixed ApplicationContext loading issue by removing conflicting H2 database configuration

## Test Results
```
Tests run: 175, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## Note
The CI was showing "success" previously due to the `-Dmaven.test.failure.ignore=true` flag, but tests were actually failing. Now all tests genuinely pass.

Closes #37

🤖 Generated with [Claude Code](https://claude.ai/code)